### PR TITLE
Feature/store checksums on disk

### DIFF
--- a/taca_ngi_pipeline/__init__.py
+++ b/taca_ngi_pipeline/__init__.py
@@ -1,4 +1,4 @@
 """ Main taca_ngi_pipeline module
 """
 
-__version__ = '0.1.2'
+__version__ = '0.2.0'

--- a/taca_ngi_pipeline/deliver/cli.py
+++ b/taca_ngi_pipeline/deliver/cli.py
@@ -39,14 +39,15 @@ def deliver(ctx,deliverypath,stagingpath,uppnexid,operator,stage_only,force):
 ## project delivery
 @deliver.command()
 @click.pass_context
-@click.argument('projectid',type=click.STRING,nargs=1)
+@click.argument('projectid',type=click.STRING,nargs=-1)
 def project(ctx, projectid):
-    """ Deliver the specified project to the specified destination
+    """ Deliver the specified projects to the specified destination
     """
-    d = _deliver.ProjectDeliverer(
-        projectid,
-        **ctx.parent.params)
-    _exec_delivery(d,d.deliver_project)
+    for pid in projectid:
+        d = _deliver.ProjectDeliverer(
+            pid,
+            **ctx.parent.params)
+        _exec_delivery(d,d.deliver_project)
     
 ## sample delivery
 @deliver.command()

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -142,6 +142,9 @@ class Deliverer(object):
         """
         def get_hash(sourcepath,destpath):
             hash = None
+            # ignore checksum files
+            if sourcepath.endswith(".{}".format(self.hash_algorithm)):
+                return (None,None,None)
             if not self.no_checksum:
                 checksumpath = "{}.{}".format(sourcepath,self.hash_algorithm)
                 if not os.path.exists(checksumpath):
@@ -190,6 +193,8 @@ class Deliverer(object):
             with open(digestpath,'w') as dh:
                 agent = transfer.SymlinkAgent(None, None, relative=True)
                 for src, dst, digest in self.gather_files():
+                    if src is None:
+                        continue
                     agent.src_path = src
                     agent.dest_path = dst
                     try:

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -140,18 +140,18 @@ class Deliverer(object):
                 destination path and the checksum of the source file 
                 (or None if source is a folder)
         """
-        def _get_hash(sourcepath,destpath):
-            hash = None
+        def _get_digest(sourcepath,destpath):
+            digest = None
             if not self.no_checksum:
                 checksumpath = "{}.{}".format(sourcepath,self.hash_algorithm)
                 if not os.path.exists(checksumpath):
-                    hash = hashfile(sourcepath,hasher=self.hash_algorithm)
+                    digest = hashfile(sourcepath,hasher=self.hash_algorithm)
                     with open(checksumpath,'w') as fh:
-                        fh.write(hash)
+                        fh.write(digest)
                 else:
                     with open(checksumpath,'r') as fh:
-                        hash = fh.next()
-            return (sourcepath,destpath,hash)
+                        digest = fh.next()
+            return (sourcepath,destpath,digest)
             
         def _walk_files(currpath, destpath):
             # if current path is a folder, return all files below it
@@ -178,7 +178,7 @@ class Deliverer(object):
                     # ignore checksum files
                     if not spath.endswith(".{}".format(self.hash_algorithm)):
                         matches += 1
-                        yield _get_hash(spath,dpath)
+                        yield _get_digest(spath,dpath)
             if matches == 0:
                 logger.warning("no files matching search expression '{}' "\
                     "found ".format(src_path))

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -6,6 +6,7 @@ import glob
 import logging
 import os
 import re
+import signal
 
 from ngi_pipeline.database import classes as db
 from ngi_pipeline.utils.classes import memoized
@@ -18,8 +19,17 @@ logger = logging.getLogger(__name__)
 
 class DelivererError(Exception): pass
 class DelivererDatabaseError(DelivererError): pass
+class DelivererInterruptedError(DelivererError): pass
 class DelivererReplaceError(DelivererError): pass
 class DelivererRsyncError(DelivererError): pass
+
+def _signal_handler(signal, frame):
+    """ A custom signal handler which will raise a DelivererInterruptedError
+        :raises DelivererInterruptedError: 
+            this exception will be raised
+    """
+    raise DelivererInterruptedError(
+        "interrupt signal {} received while delivering".format(signal))
 
 class Deliverer(object):
     """ 
@@ -51,6 +61,9 @@ class Deliverer(object):
                 self,'uppnexid',self.project_entry()['uppnex_id'])
         except KeyError:
             pass
+        # set a custom signal handler to intercept interruptions
+        signal.signal(signal.SIGINT,_signal_handler)
+        signal.signal(signal.SIGTERM,_signal_handler)
 
     def __str__(self):
         return "{}:{}".format(
@@ -142,7 +155,10 @@ class Deliverer(object):
             
         for sfile, dfile in getattr(self,'files_to_deliver',[]):
             dest_path = self.expand_path(dfile)
-            for f in glob.iglob(self.expand_path(sfile)):
+            src_path = self.expand_path(sfile)
+            matches = 0
+            for f in glob.iglob(src_path):
+                matches += 1
                 if (os.path.isdir(f)):
                     fparent = os.path.dirname(f)
                     # walk over all folders and files below
@@ -155,7 +171,10 @@ class Deliverer(object):
                 else:
                     yield get_hash(f,
                         os.path.join(dest_path,os.path.basename(f)))
-    
+            if matches == 0:
+                logger.warning("no files matching search expression '{}' "\
+                    "found ".format(src_path))
+
     def stage_delivery(self):
         """ Stage a delivery by symlinking source paths to destination paths 
             according to the returned tuples from the gather_files function. 
@@ -271,25 +290,42 @@ class ProjectDeliverer(Deliverer):
             :returns: True if all samples were delivered successfully, False if
                 any sample was not properly delivered or ready to be delivered
         """
-        logger.info("Delivering {} to {}".format(str(self),self.deliverypath))
         try:
-            sampleentries = self.project_sample_entries()
-        except DelivererDatabaseError as e:
-            logger.error("error '{}' occurred during delivery of {}"
-                         .format(str(e), str(self)))
-            raise
-        # right now, don't catch any errors since we're assuming any thrown 
-        # errors needs to be handled by manual intervention
-        status = True
-        for sampleentry in sampleentries.get('samples',[]):
-            st = SampleDeliverer(
-                self.projectid,sampleentry.get('sampleid')
-            ).deliver_sample(sampleentry)
-            status = (status and st)
+            logger.info("Delivering {} to {}".format(
+                str(self),self.expand_path(self.deliverypath)))
+            projectentry = self.project_entry()
+            if projectentry.get('delivery_status') == 'DELIVERED' \
+                and not self.force:
+                logger.info("{} has already been delivered".format(str(self)))
+                return True
+            try:
+                sampleentries = self.project_sample_entries()
+            except DelivererDatabaseError as e:
+                logger.error("error '{}' occurred during delivery of {}".format(
+                    str(e), str(self)))
+                raise
+            # right now, don't catch any errors since we're assuming any thrown 
+            # errors needs to be handled by manual intervention
+            self.update_delivery_status(status="IN_PROGRESS")
+            status = True
+            for sampleentry in sampleentries.get('samples',[]):
+                st = SampleDeliverer(
+                    self.projectid,sampleentry.get('sampleid')
+                ).deliver_sample(sampleentry)
+                status = (status and st)
             
-        if status:
-            self.update_delivery_status()
-        return status
+            if status:
+                self.update_delivery_status(status="DELIVERED")
+            else:
+                self.update_delivery_status(status="NOT DELIVERED")
+            return status
+        except DelivererInterruptedError as e:
+            self.update_delivery_status(status="NOT DELIVERED")
+            raise
+        except Exception as e:
+            self.update_delivery_status(status="FAILED")
+            raise
+            
 
     def update_delivery_status(self, status="DELIVERED"):
         """ Update the delivery_status field in the database to the supplied 
@@ -328,39 +364,48 @@ class SampleDeliverer(Deliverer):
                 has taken place but should be replaced
             :raises DelivererError: if the delivery failed
         """
-        logger.info("Delivering {} to {}".format(str(self), self.deliverypath))
         try:
-            sampleentry = sampleentry or self.sample_entry()
-        except DelivererDatabaseError as e:
-            logger.error(
-                "error '{}' occurred during delivery of {}".format(
-                    str(e),str(self)))
+            logger.info("Delivering {} to {}".format(
+                str(self),self.expand_path(self.deliverypath)))
+            try:
+                sampleentry = sampleentry or self.sample_entry()
+            except DelivererDatabaseError as e:
+                logger.error(
+                    "error '{}' occurred during delivery of {}".format(
+                        str(e),str(self)))
+                raise
+            if sampleentry.get('delivery_status') == 'DELIVERED' and not self.force:
+                logger.info("{} has already been delivered".format(str(self)))
+                return True
+            elif sampleentry.get('delivery_status') == 'IN_PROGRESS' \
+                and not self.force:
+                logger.info("delivery of {} is already in progress".format(
+                    str(self)))
+                return False
+            elif sampleentry.get('analysis_status') != 'ANALYZED' \
+                and not self.force:
+                logger.info("{} has not finished analysis and will not be "\
+                    "delivered".format(str(self)))
+                return False
+            else:
+                # Propagate raised errors upwards, they should trigger 
+                # notification to operator
+                self.update_delivery_status(status="IN_PROGRESS")
+                if not self.stage_delivery():
+                    raise DelivererError("sample was not properly staged")
+                logger.info("{} successfully staged".format(str(self)))
+                if not self.stage_only:
+                    if not self.do_delivery():
+                        raise DelivererError("sample was not properly delivered")
+                    logger.info("{} successfully delivered".format(str(self)))
+                    self.update_delivery_status()
+                return True
+        except DelivererInterruptedError as e:
+            self.update_delivery_status(status="NOT DELIVERED")
             raise
-        if sampleentry.get('delivery_status') == 'DELIVERED' and not self.force:
-            logger.info("{} has already been delivered".format(str(self)))
-            return True
-        elif sampleentry.get('delivery_status') == 'IN_PROGRESS' \
-            and not self.force:
-            logger.info("delivery of {} is already in progress".format(
-                str(self)))
-            return False
-        elif sampleentry.get('analysis_status') != 'ANALYZED' \
-            and not self.force:
-            logger.info("{} has not finished analysis and will not be "\
-                "delivered".format(str(self)))
-            return False
-        else:
-            # Propagate raised errors upwards, they should trigger 
-            # notification to operator
-            if not self.stage_delivery():
-                raise DelivererError("sample was not properly staged")
-            logger.info("{} successfully staged".format(str(self)))
-            if not self.stage_only:
-                if not self.do_delivery():
-                    raise DelivererError("sample was not properly delivered")
-                logger.info("{} successfully delivered".format(str(self)))
-                self.update_delivery_status()
-            return True
+        except Exception as e:
+            self.update_delivery_status(status="FAILED")
+            raise
     
     def do_delivery(self):
         """ Deliver the staged delivery folder using rsync

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -34,6 +34,8 @@ SAMPLECFG = {
             '_STAGINGPATH_'],
             ['_DATAPATH_/level1_folder1/level2_folder1/level3_folder1',
             '_STAGINGPATH_'],
+            ['_DATAPATH_/level1_folder1/level1_folder1_file1.md5',
+            '_STAGINGPATH_'],
         ]}}
 
 class TestDeliverer(unittest.TestCase):  
@@ -250,6 +252,16 @@ class TestDeliverer(unittest.TestCase):
         self.deliverer.files_to_deliver = [pattern]
         self.assertItemsEqual(
             [p for p,_,_ in self.deliverer.gather_files()],
+            expected)
+
+    def test_gather_files8(self):
+        """ Skip checksum files """
+        expected = [(None,None,None)]
+        pattern = SAMPLECFG['deliver']['files_to_deliver'][7]
+        self.deliverer.files_to_deliver = [pattern]
+        open(self.deliverer.expand_path(pattern[0]),'w').close()
+        self.assertItemsEqual(
+            [obs for obs in self.deliverer.gather_files()],
             expected)
     
     def test_stage_delivery1(self):

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -3,8 +3,10 @@
 import mock
 import os
 import shutil
+import signal
 import tempfile
 import unittest
+
 from ngi_pipeline.database import classes as db
 from taca_ngi_pipeline.deliver import deliver
 from taca.utils.transfer import SymlinkError, SymlinkAgent
@@ -386,6 +388,18 @@ class TestProjectDeliverer(unittest.TestCase):
             self.projectid,
             delivery_status="DELIVERED")
 
+    def test_catching_sigint(self):
+        """ SIGINT should raise DelivererInterruptedError
+        """
+        with self.assertRaises(deliver.DelivererInterruptedError):
+            os.kill(os.getpid(),signal.SIGINT)
+
+    def test_catching_sigterm(self):
+        """ SIGTERM should raise DelivererInterruptedError
+        """
+        with self.assertRaises(deliver.DelivererInterruptedError):
+            os.kill(os.getpid(),signal.SIGTERM)
+
 class TestSampleDeliverer(unittest.TestCase):  
     
     @classmethod
@@ -429,4 +443,16 @@ class TestSampleDeliverer(unittest.TestCase):
             self.projectid,
             self.sampleid,
             delivery_status="DELIVERED")
+
+    def test_catching_sigint(self):
+        """ SIGINT should raise DelivererInterruptedError
+        """
+        with self.assertRaises(deliver.DelivererInterruptedError):
+            os.kill(os.getpid(),signal.SIGINT)
+
+    def test_catching_sigterm(self):
+        """ SIGTERM should raise DelivererInterruptedError
+        """
+        with self.assertRaises(deliver.DelivererInterruptedError):
+            os.kill(os.getpid(),signal.SIGTERM)
         

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -256,7 +256,7 @@ class TestDeliverer(unittest.TestCase):
 
     def test_gather_files8(self):
         """ Skip checksum files """
-        expected = [(None,None,None)]
+        expected = []
         pattern = SAMPLECFG['deliver']['files_to_deliver'][7]
         self.deliverer.files_to_deliver = [pattern]
         open(self.deliverer.expand_path(pattern[0]),'w').close()


### PR DESCRIPTION
- enable specifying multiple projects on command line
- catch SIGINT and SIGTERM signals and raise an error for graceful shutdown
- parse checksums from checksum file if it exists, else calculate on-the-fly and store in checksum file
- warn if a file glob does not yield any matches
- use delivery statuses "IN_PROGRESS" and "FAILED" for projects and samples
- tests for checksum caching and interrupt signal interception
