### PR TITLE
Hotfix/avoid redundant sample uploads

### DIFF
--- a/taca_ngi_pipeline/__init__.py
+++ b/taca_ngi_pipeline/__init__.py
@@ -1,4 +1,4 @@
 """ Main taca_ngi_pipeline module
 """
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -214,6 +214,8 @@ class Deliverer(object):
                     fh.write("{}\n".format(fpath))
                     if digest is not None:
                         dh.write("{}  {}\n".format(digest,fpath))
+                # finally, include the digestfile in the list of files to deliver
+                fh.write("{}\n".format(os.path.basename(digestpath)))
         except IOError as e:
             raise DelivererError(
                 "failed to stage delivery - reason: {}".format(e))
@@ -226,7 +228,6 @@ class Deliverer(object):
         return self.expand_path(
             os.path.join(
                 self.deliverypath,
-                self.projectid,
                 os.path.basename(self.staging_digestfile())))
 
     def staging_digestfile(self):
@@ -346,7 +347,6 @@ class ProjectDeliverer(Deliverer):
         except Exception as e:
             self.update_delivery_status(status="FAILED")
             raise
-            
 
     def update_delivery_status(self, status="DELIVERED"):
         """ Update the delivery_status field in the database to the supplied 
@@ -442,7 +442,7 @@ class SampleDeliverer(Deliverer):
             remote_user=getattr(self,'remote_user', None), 
             log=logger,
             opts={
-                '--files-from': self.staging_filelist(),
+                '--files-from': [self.staging_filelist()],
                 '--copy-links': None,
                 '--recursive': None,
                 '--perms': None,

--- a/tests/data/taca_test_cfg.yaml
+++ b/tests/data/taca_test_cfg.yaml
@@ -1,11 +1,11 @@
 log:
-    log_file: data/taca.log
+    file: data/taca.log
 
 deliver:
     analysispath: data/ANALYSIS/_PROJECTID_
     datapath: data/DATA/_PROJECTID_
     stagingpath: data/STAGING/_PROJECTID_
-    deliverypath: data/DELIVERY
+    deliverypath: data/DELIVERY/_PROJECTID_
     operator: operator@domain.com
     files_to_deliver:
         -


### PR DESCRIPTION
- use a file list specifying files to transfer with rsync, mainly to avoid unnecessary work by rsync
- drop hardcoded project id in delivery path, this should be specified in configuration instead
- **NOTE** as a consequence of the change above, the configuration needs to be modified to reflect this
- added a test case for transferring a sample
 