### PR TITLE
Feature/write delivery acknowledgement file

### DIFF
--- a/taca_ngi_pipeline/__init__.py
+++ b/taca_ngi_pipeline/__init__.py
@@ -1,4 +1,4 @@
 """ Main taca_ngi_pipeline module
 """
 
-__version__ = '0.3.0'
+__version__ = '0.3.2'

--- a/taca_ngi_pipeline/__init__.py
+++ b/taca_ngi_pipeline/__init__.py
@@ -1,4 +1,4 @@
 """ Main taca_ngi_pipeline module
 """
 
-__version__ = '0.3.1'
+__version__ = '0.3.0'

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -178,12 +178,7 @@ class Deliverer(object):
                     # ignore checksum files
                     if not spath.endswith(".{}".format(self.hash_algorithm)):
                         matches += 1
-                        # skip and warn if a path does not exist, this includes broken symlinks
-                        if os.path.exists(spath):
-                            yield _get_digest(spath,dpath)
-                        else:
-                            logger.warning("path {} does not exist, possibly " \
-                                "because of a broken symlink".format(spath))
+                        yield _get_digest(spath,dpath)
             if matches == 0:
                 logger.warning("no files matching search expression '{}' "\
                     "found ".format(src_path))

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -66,6 +66,8 @@ class Deliverer(object):
             self,'hash_algorithm','sha1')
         self.no_checksum = getattr(
             self,'no_checksum',False)
+        self.ngi_node = getattr(
+            self,'ngi_node','unknown')
         # only set an attribute for uppnexid if it's actually given or in the db
         try:
             self.uppnexid = getattr(
@@ -372,7 +374,7 @@ class ProjectDeliverer(Deliverer):
              logprefix = None
         with chdir(self.expand_path(self.reportpath)):
             call_external_command(
-                "ngi_reports ign_aggregate_report",
+                "ngi_reports ign_aggregate_report -n {}".format(self.ngi_node),
                 with_log_files=(logprefix is not None),
                 prefix=logprefix)
 
@@ -449,15 +451,15 @@ class SampleDeliverer(Deliverer):
         with chdir(self.expand_path(self.reportpath)):
             # create the ign_sample_report for this sample
             call_external_command(
-                "ngi_reports ign_sample_report --samples '{}'".format(
-                    self.sampleid),
+                "ngi_reports ign_sample_report -n {} --samples '{}'".format(
+                    self.ngi_node,self.sampleid),
                 with_log_files=(logprefix is not None),
                 prefix=logprefix)
             # estimate the delivery date for this sample to 0.5 days ahead
             call_external_command(
-                "ngi_reports ign_aggregate_report --samples_extra "\
+                "ngi_reports ign_aggregate_report -n {} --samples_extra "\
                 "'{\"{}\": {\"delivered\": \"{}\"}}'".format(
-                    self.sampleid,_timestamp(days=0.5)),
+                    self.ngi_node,self.sampleid,_timestamp(days=0.5)),
                 with_log_files=(logprefix is not None),
                 prefix=logprefix)
 

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -84,7 +84,7 @@ class Deliverer(object):
     def acknowledge_delivery(self, tstamp=_timestamp()):
         try:
             ackfile = self.expand_path(
-                os.path.join(self.logpath,"{}_delivered.ack".format(
+                os.path.join(self.deliverystatuspath,"{}_delivered.ack".format(
                     self.sampleid or self.projectid)))
             create_folder(os.path.dirname(ackfile))
             with open(ackfile,'w') as fh:
@@ -296,7 +296,7 @@ class Deliverer(object):
         """
         return self.expand_path(
             os.path.join(
-                self.stagingpath,
+                self.logpath,
                 "{}_{}".format(self.sampleid,
                     datetime.datetime.now().strftime("%Y%m%dT%H%M%S"))))
                 
@@ -370,7 +370,7 @@ class ProjectDeliverer(Deliverer):
                 logprefix = None
         except AttributeError as e:
              logprefix = None
-        with chdir(self.expand_path(self.analysispath)):
+        with chdir(self.expand_path(self.reportpath)):
             call_external_command(
                 "ngi_reports ign_aggregate_report",
                 with_log_files=(logprefix is not None),
@@ -446,7 +446,7 @@ class SampleDeliverer(Deliverer):
                 logprefix = None
         except AttributeError as e:
              logprefix = None
-        with chdir(self.expand_path(self.analysispath)):
+        with chdir(self.expand_path(self.reportpath)):
             # create the ign_sample_report for this sample
             call_external_command(
                 "ngi_reports ign_sample_report --samples '{}'".format(
@@ -569,6 +569,7 @@ class SampleDeliverer(Deliverer):
                 '--verbose': None,
                 '--exclude': ["*rsync.out","*rsync.err"]
             })
+        create_folder(os.path.dirname(self.transfer_log()))
         try:
             return agent.transfer(transfer_log=self.transfer_log())
         except transfer.TransferError as e:

--- a/tests/data/taca_test_cfg.yaml
+++ b/tests/data/taca_test_cfg.yaml
@@ -6,8 +6,10 @@ deliver:
     datapath: data/DATA/_PROJECTID_
     stagingpath: data/STAGING/_PROJECTID_
     deliverypath: data/DELIVERY/_PROJECTID_
-    logpath: _ANALYSISPATH_/logs
     report: True
+    reportpath: _ANALYSISPATH_/piper_ngi
+    logpath: _REPORTPATH_/logs
+    deliverystatuspath: _REPORTPATH_/08_misc
     operator: operator@domain.com
     files_to_deliver:
         -

--- a/tests/data/taca_test_cfg.yaml
+++ b/tests/data/taca_test_cfg.yaml
@@ -6,6 +6,8 @@ deliver:
     datapath: data/DATA/_PROJECTID_
     stagingpath: data/STAGING/_PROJECTID_
     deliverypath: data/DELIVERY/_PROJECTID_
+    logpath: _ANALYSISPATH_/logs
+    report: True
     operator: operator@domain.com
     files_to_deliver:
         -

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -23,6 +23,8 @@ SAMPLECFG = {
         'deliverypath': '_ROOTDIR_/DELIVERY_DESTINATION',
         'operator': 'operator@domain.com',
         'logpath': '_ROOTDIR_/ANALYSIS/logs',
+        'reportpath': '_ANALYSISPATH_',
+        'deliverystatuspath': '_ANALYSISPATH_',
         'hash_algorithm': 'md5',
         'files_to_deliver': [
             ['_ANALYSISPATH_/level0_folder?_file*',
@@ -405,17 +407,16 @@ class TestDeliverer(unittest.TestCase):
     def test_acknowledge_sample_delivery(self):
         """ A delivery acknowledgement should be written if requirements are met
         """
-        # without the logpath attribute, no acknowledgement should be written
-        del self.deliverer.logpath
+        # without the deliverystatuspath attribute, no acknowledgement should be written
+        del self.deliverer.deliverystatuspath
         self.deliverer.acknowledge_delivery()
         ackfile = os.path.join(
-            self.deliverer.expand_path(SAMPLECFG['deliver']['logpath']),
+            self.deliverer.expand_path(SAMPLECFG['deliver']['deliverystatuspath']),
             "{}_delivered.ack".format(self.sampleid))
         self.assertFalse(os.path.exists(ackfile),
             "delivery acknowledgement was created but it shouldn't have been")
-        # with the logpath attribute, acknowledgement should be written with
-        # the supplied timestamp
-        self.deliverer.logpath = SAMPLECFG['deliver']['logpath']
+        # with the deliverystatuspath attribute, acknowledgement should be written with the supplied timestamp
+        self.deliverer.deliverystatuspath = SAMPLECFG['deliver']['deliverystatuspath']
         for t in [deliver._timestamp(),"this-is-a-timestamp"]:
             self.deliverer.acknowledge_delivery(tstamp=t)
             self.assertTrue(os.path.exists(ackfile),
@@ -482,7 +483,7 @@ class TestProjectDeliverer(unittest.TestCase):
         """ A project delivery acknowledgement should be written to disk """
         self.deliverer.acknowledge_delivery()
         ackfile = os.path.join(
-            self.deliverer.expand_path(SAMPLECFG['deliver']['logpath']),
+            self.deliverer.expand_path(SAMPLECFG['deliver']['deliverystatuspath']),
             "{}_delivered.ack".format(self.projectid))
         self.assertTrue(os.path.exists(ackfile),
             "delivery acknowledgement not created")
@@ -614,7 +615,7 @@ class TestSampleDeliverer(unittest.TestCase):
     def test_acknowledge_sample_delivery(self):
         """ A sample delivery acknowledgement should be written to disk """
         ackfile = os.path.join(
-            self.deliverer.expand_path(SAMPLECFG['deliver']['logpath']),
+            self.deliverer.expand_path(SAMPLECFG['deliver']['deliverystatuspath']),
             "{}_delivered.ack".format(self.sampleid))
         self.deliverer.acknowledge_delivery()
         self.assertTrue(os.path.exists(ackfile),

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -264,22 +264,7 @@ class TestDeliverer(unittest.TestCase):
         self.assertItemsEqual(
             [obs for obs in self.deliverer.gather_files()],
             expected)
-
-    def test_gather_files9(self):
-        """ Do not attempt to process broken symlinks """
-        expected = []
-        pattern = SAMPLECFG['deliver']['files_to_deliver'][5]
-        spath = self.deliverer.expand_path(pattern[0])
-        os.unlink(spath)
-        os.symlink(
-            os.path.join(
-                os.path.dirname(spath),
-                "this-file-does-not-exist"),
-            spath)
-        self.deliverer.files_to_deliver = [pattern]
-        observed = [p for p,_,_ in self.deliverer.gather_files()]
-        self.assertItemsEqual(observed,expected)
-
+    
     def test_stage_delivery1(self):
         """ The correct folder structure should be created and exceptions 
             handled gracefully


### PR DESCRIPTION
- ign_sample_reports and in_aggregate_reports will be created during delivery if the configuration option 'report' is set to true and the ngi_reports script is available in the environment
- when delivery has finished, a file with a timestamp will be written to disk
- some updates to paths in the configuration, rsync logs are now written under the ANALYSIS folder rather than the staging folder
- improvements to properly handle concurrently running transfers which should significantly reduce the risk of race conditions
- some general refactoring
