### PR TITLE
Hotfix/fix uppnexid lookup

### DIFF
--- a/taca_ngi_pipeline/__init__.py
+++ b/taca_ngi_pipeline/__init__.py
@@ -1,4 +1,4 @@
 """ Main taca_ngi_pipeline module
 """
 
-__version__ = '0.3.2'
+__version__ = '0.3.3'

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -71,8 +71,8 @@ class Deliverer(object):
         # only set an attribute for uppnexid if it's actually given or in the db
         try:
             self.uppnexid = getattr(
-                self,'uppnexid',self.db_entry()['uppnex_id'])
-        except (KeyError, NotImplementedError) as e:
+                self,'uppnexid',self.project_entry()['uppnex_id'])
+        except KeyError as e:
             pass
         # set a custom signal handler to intercept interruptions
         signal.signal(signal.SIGINT,_signal_handler)
@@ -107,6 +107,15 @@ class Deliverer(object):
         """ Abstract method, should be implemented by subclasses """
         raise NotImplementedError("This method should be implemented by "\
         "subclass")
+
+    def project_entry(self):
+        """ Fetch a database entry representing the instance's project
+            :returns: a json-formatted database entry
+            :raises DelivererDatabaseError:
+                if an error occurred when communicating with the database
+        """
+        return self.wrap_database_query(
+            self.dbcon().project_get,self.projectid)
 
     def project_sample_entries(self):
         """ Fetch the database sample entries representing the instance's project
@@ -384,8 +393,7 @@ class ProjectDeliverer(Deliverer):
             :raises DelivererDatabaseError:
                 if an error occurred when communicating with the database
         """
-        return self.wrap_database_query(
-            self.dbcon().project_get,self.projectid)
+        return self.project_entry()
 
     def deliver_project(self):
         """ Deliver all samples in a project to the destination specified by 

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -70,10 +70,13 @@ class Deliverer(object):
             self,'ngi_node','unknown')
         # only set an attribute for uppnexid if it's actually given or in the db
         try:
-            self.uppnexid = getattr(
-                self,'uppnexid',self.project_entry()['uppnex_id'])
-        except KeyError as e:
-            pass
+            t = self.uppnexid
+        except AttributeError:
+            try:
+                t = self.project_entry()['uppnex_id']
+                self.uppnexid = t
+            except KeyError:
+                pass
         # set a custom signal handler to intercept interruptions
         signal.signal(signal.SIGINT,_signal_handler)
         signal.signal(signal.SIGTERM,_signal_handler)

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -52,7 +52,8 @@ SAMPLEENTRY = json.loads(
 PROJECTENTRY = json.loads(
     '{"delivery_status": "this-is-the-project-delivery-status", '\
     '"analysis_status": "this-is-the-project-analysis-status", '\
-    '"projectid": "NGIU-P001"}')
+    '"projectid": "NGIU-P001", '\
+    '"uppnex_id": "a2099999"}')
 PROJECTENTRY['samples'] = [SAMPLEENTRY]
 
 class TestDeliverer(unittest.TestCase):  
@@ -548,7 +549,21 @@ class TestSampleDeliverer(unittest.TestCase):
         self.assertIsInstance(
             getattr(self,'deliverer'),
             deliver.SampleDeliverer)
-    
+
+    @mock.patch.object(
+        deliver.db.CharonSession,'project_get',return_value=PROJECTENTRY)
+    def test_fetch_uppnexid(self,dbmock):
+        """ A SampleDeliverer should be able to fetch the Uppnex ID for the 
+            project
+        """
+        self.deliverer = deliver.SampleDeliverer(
+            self.projectid,
+            self.sampleid,
+            rootdir=self.casedir,
+            **SAMPLECFG['deliver'])
+        self.assertEquals(self.deliverer.uppnexid,PROJECTENTRY['uppnex_id'])
+        dbmock.assert_called_with(self.projectid)
+
     @mock.patch.object(
         deliver.db.CharonSession,
         'sample_update',

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -556,13 +556,24 @@ class TestSampleDeliverer(unittest.TestCase):
         """ A SampleDeliverer should be able to fetch the Uppnex ID for the 
             project
         """
-        self.deliverer = deliver.SampleDeliverer(
+        # if an uppnexid is given in the configuration, it should be used and the database should not be queried
+        deliverer = deliver.SampleDeliverer(
+            self.projectid,
+            self.sampleid,
+            rootdir=self.casedir,
+            uppnexid="this-is-the-uppnexid",
+            **SAMPLECFG['deliver'])
+        self.assertEquals(deliverer.uppnexid,"this-is-the-uppnexid")
+        self.assertFalse(dbmock.called,
+            "the database should not have been queried")
+        # if an uppnexid is not supplied in the config, the database should be consulted
+        deliverer = deliver.SampleDeliverer(
             self.projectid,
             self.sampleid,
             rootdir=self.casedir,
             **SAMPLECFG['deliver'])
-        self.assertEquals(self.deliverer.uppnexid,PROJECTENTRY['uppnex_id'])
-        dbmock.assert_called_with(self.projectid)
+        self.assertEquals(deliverer.uppnexid,PROJECTENTRY['uppnex_id'])
+        dbmock.assert_called_once_with(self.projectid)
 
     @mock.patch.object(
         deliver.db.CharonSession,


### PR DESCRIPTION
- There was a problem where the database entry for the sample was used to fetch the uppnex_id instead of the project entry
- Wrote a test to verify that the uppnex_id can be properly retrieved