### PR TITLE
parse report tool command line from config

### DIFF
--- a/taca_ngi_pipeline/__init__.py
+++ b/taca_ngi_pipeline/__init__.py
@@ -1,4 +1,4 @@
 """ Main taca_ngi_pipeline module
 """
 
-__version__ = '0.3.5'
+__version__ = '0.4.1'

--- a/tests/data/taca_test_cfg.yaml
+++ b/tests/data/taca_test_cfg.yaml
@@ -6,8 +6,8 @@ deliver:
     datapath: data/DATA/_PROJECTID_
     stagingpath: data/STAGING/_PROJECTID_
     deliverypath: data/DELIVERY/_PROJECTID_
-    report: True
-    ngi_node: uppsala
+    report_aggregate: ngi_reports ign_aggregate_report -n uppsala --pandoc_binary
+    report_sample: ngi_reports ign_sample_report -n uppsala --pandoc_binary
     reportpath: _ANALYSISPATH_/piper_ngi
     logpath: _REPORTPATH_/logs
     deliverystatuspath: _REPORTPATH_/08_misc

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -24,6 +24,8 @@ SAMPLECFG = {
         'operator': 'operator@domain.com',
         'logpath': '_ROOTDIR_/ANALYSIS/logs',
         'reportpath': '_ANALYSISPATH_',
+        'report_aggregate': 'ngi_reports ign_aggregate_report -n uppsala',
+        'report_sample': 'ngi_reports ign_sample_report -n uppsala',
         'deliverystatuspath': '_ANALYSISPATH_',
         'hash_algorithm': 'md5',
         'files_to_deliver': [
@@ -519,6 +521,13 @@ class TestProjectDeliverer(unittest.TestCase):
             dbmock.assert_called_with(PROJECTENTRY['projectid'])
         PROJECTENTRY['samples'] = [SAMPLEENTRY]
 
+    def test_create_project_report(self):
+        """ creating the project report """
+        with mock.patch.object(deliver,'call_external_command') as syscall:
+            self.deliverer.create_report()
+            self.assertEqual(
+                " ".join(syscall.call_args[0][0]),
+                SAMPLECFG['deliver']['report_aggregate'])
 
 class TestSampleDeliverer(unittest.TestCase):  
     
@@ -668,3 +677,17 @@ class TestSampleDeliverer(unittest.TestCase):
             self.deliverer.get_analysis_status(),
             SAMPLEENTRY.get('analysis_status'))
         dbmock.assert_called_with(self.projectid,SAMPLEENTRY.get('sampleid'))
+
+    def test_create_sample_report(self):
+        """ creating the sample report """
+        with mock.patch.object(deliver,'call_external_command') as syscall:
+            self.deliverer.create_report()
+            self.assertEqual(
+                " ".join(syscall.call_args_list[0][0][0]),
+                "{} --samples {}".format(
+                    SAMPLECFG['deliver']['report_sample'],
+                    self.deliverer.sampleid))
+            self.assertEqual(
+                " ".join(syscall.call_args_list[1][0][0][:-1]),
+                "{} --samples_extra".format(
+                    SAMPLECFG['deliver']['report_aggregate']))


### PR DESCRIPTION
- refactored so that most of the command line for generating reports are specified in the taca config