### PR TITLE
Mosler delivery support

### DIFF
--- a/dependency_links.txt
+++ b/dependency_links.txt
@@ -1,2 +1,2 @@
-https://github.com/NationalGenomicsInfrastructure/ngi_pipeline/archive/devel.zip#egg=ngi_pipeline
+https://github.com/NationalGenomicsInfrastructure/ngi_pipeline/archive/master.zip#egg=ngi_pipeline
 https://github.com/SciLifeLab/statusdb/archive/master.zip#egg=statusdb

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 pyyaml
 taca>=0.1.9
 ngi_pipeline
+paramiko

--- a/taca_ngi_pipeline/cli.py
+++ b/taca_ngi_pipeline/cli.py
@@ -74,7 +74,12 @@ def sample(ctx, projectid, sampleid):
 @click.pass_context
 @click.argument('projectid', type=click.STRING, nargs=-1)
 def mosler(ctx, projectid):
-    """ Deliver the specified projects to MOSLER (with capitol letters... MOSLER!!!!!)
+    """ Deliver the specified projects to MOSLER. Ideally this needs to be used only once when all samples of the project
+        have been sequenced and analysed. mosler subcommand creates a tar file for each sample and moves data to mosler.
+        Mosler password (i.e., user-password and token) need to be inserted once.
+        It is suggested to stage the project locally before deliveing it.
+        If the delivery of the same sample is forced multiple times the user will find multiple directories in the INBOX 
+        folder containing the a tar register with the same name.
     """
     for pid in projectid:
         d = _deliver_mosler.MoslerProjectDeliverer(

--- a/taca_ngi_pipeline/cli.py
+++ b/taca_ngi_pipeline/cli.py
@@ -4,6 +4,7 @@ import click
 import logging
 import taca.utils.misc
 from deliver import deliver as _deliver
+from deliver import deliver_mosler as _deliver_mosler
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +67,20 @@ def sample(ctx, projectid, sampleid):
             sid,
             **ctx.parent.params)
         _exec_fn(d, d.deliver_sample)
+
+# mosler delivery
+# project delivery
+@deliver.command()
+@click.pass_context
+@click.argument('projectid', type=click.STRING, nargs=-1)
+def mosler(ctx, projectid):
+    """ Deliver the specified projects to MOSLER (with capitol letters... MOSLER!!!!!)
+    """
+    for pid in projectid:
+        d = _deliver_mosler.ProjectDeliverer(
+            pid,
+            **ctx.parent.params)
+        _exec_fn(d, d.deliver_project)
 
 
 # helper function to handle error reporting

--- a/taca_ngi_pipeline/cli.py
+++ b/taca_ngi_pipeline/cli.py
@@ -77,7 +77,7 @@ def mosler(ctx, projectid):
     """ Deliver the specified projects to MOSLER (with capitol letters... MOSLER!!!!!)
     """
     for pid in projectid:
-        d = _deliver_mosler.ProjectDeliverer(
+        d = _deliver_mosler.MoslerProjectDeliverer(
             pid,
             **ctx.parent.params)
         _exec_fn(d, d.deliver_project)

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -86,11 +86,6 @@ class Deliverer(object):
         self.reportpath = getattr(self, 'reportpath', None)
         self.force = getattr(self, 'force', False)
         self.stage_only = getattr(self, 'stage_only', False)
-        # Mosler specific fields
-        self.moslerdeliverypath = getattr(self, 'moslerdeliverypath', None)
-        self.moslersftpserver = getattr(self, 'moslersftpserver', None)
-        self.moslersftpserver_user = getattr(self, 'moslersftpserver_user', None)
-        self.moslersftpmaxfiles = getattr(self, 'moslersftpmaxfiles', None)
         # only set an attribute for uppnexid if it's actually given or in the db
         try:
             getattr(self, 'uppnexid')

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -86,6 +86,11 @@ class Deliverer(object):
         self.reportpath = getattr(self, 'reportpath', None)
         self.force = getattr(self, 'force', False)
         self.stage_only = getattr(self, 'stage_only', False)
+        # Mosler specific fields
+        self.moslerdeliverypath = getattr(self, 'moslerdeliverypath', None)
+        self.moslersftpserver = getattr(self, 'moslersftpserver', None)
+        self.moslersftpserver_user = getattr(self, 'moslersftpserver_user', None)
+        self.moslersftpmaxfiles = getattr(self, 'moslersftpmaxfiles', None)
         # only set an attribute for uppnexid if it's actually given or in the db
         try:
             getattr(self, 'uppnexid')

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -228,7 +228,7 @@ class Deliverer(object):
             os.path.join(
                 self.stagingpath,
                 "{}.lst".format(self.sampleid)))
-
+ 
     def transfer_log(self):
         """
             :returns: path prefix to the transfer log files. The suffixes will

--- a/taca_ngi_pipeline/deliver/deliver_mosler.py
+++ b/taca_ngi_pipeline/deliver/deliver_mosler.py
@@ -268,8 +268,9 @@ class MoslerSampleDeliverer(MoslerDeliverer):
         sample_tar = tarfile.open(sample_tar_archive, "w", dereference=True)
         # add to the archive the directory
         logger.info("{} building tar file for sample".format(self.sampleid))
-        #sample_tar.add('/proj/a2014205/nobackup/NGI/analysis_ready/DELIVERY/P4107/TEST/', arcname="{}".format(self.sampleid))
-        sample_tar.add(os.path.join(sample_tar_location,  "{}.tar".format(self.sampleid)), arcname="{}".format(self.sampleid))
+        import pdb
+        pdb.set_trace()
+        sample_tar.add(os.path.join(sample_tar_location,  "{}".format(self.sampleid)), arcname="{}".format(self.sampleid))
         # close the tar ball
         logger.info("{} tar file for sample builded".format(self.sampleid))
         sample_tar.close()

--- a/taca_ngi_pipeline/deliver/deliver_mosler.py
+++ b/taca_ngi_pipeline/deliver/deliver_mosler.py
@@ -12,20 +12,10 @@ import time
 
 from deliver import *
 
-class MoslerDeliverer(Deliverer):
-
-    def __init__(self, projectid=None, sampleid=None, **kwargs):
-        super(MoslerDeliverer, self).__init__(
-            projectid,
-            sampleid,
-            **kwargs)
-        self.moslerdeliverypath = getattr(self, 'moslerdeliverypath', None)
-        self.moslersftpserver = getattr(self, 'moslersftpserver', None)
-        self.moslersftpserver_user = getattr(self, 'moslersftpserver_user', None)
-        self.moslersftpmaxfiles = getattr(self, 'moslersftpmaxfiles', None)
 
 
-class MoslerProjectDeliverer(MoslerDeliverer):
+
+class MoslerProjectDeliverer(ProjectDeliverer):
     """ This object takes care of delivering project samples to mosler.
         When delivering to Mosler the delivery can take place only at project level
     """
@@ -35,38 +25,6 @@ class MoslerProjectDeliverer(MoslerDeliverer):
             sampleid,
             **kwargs)
     
-    def all_samples_delivered(
-            self,
-            sampleentries=None):
-        """ Checks the delivery status of all project samples
-
-            :params sampleentries: a list of sample entry dicts to use instead
-                of fetching from database
-            :returns: True if all samples in this project has been successfully
-                delivered, False otherwise
-            THIS HAS BEEN COPIED AND PASTED FROM deliver.py ProjectDeliverer class
-        """
-        sampleentries = sampleentries or db.project_sample_entries(db.dbcon(), self.projectid).get('samples', [])
-        return all([self.get_delivery_status(sentry) == 'DELIVERED' for sentry in sampleentries])
-    
-    def db_entry(self):
-        """ Fetch a database entry representing the instance's project
-            :returns: a json-formatted database entry
-            :raises taca_ngi_pipeline.utils.database.DatabaseError:
-                if an error occurred when communicating with the database
-            THIS HAS BEEN COPIED AND PASTED FROM deliver.py ProjectDeliverer class
-        """
-        return db.project_entry(db.dbcon(), self.projectid)
-    
-    def update_delivery_status(self, status="DELIVERED"):
-        """ Update the delivery_status field in the database to the supplied 
-            status for the project specified by this instance
-            :returns: the result from the underlying api call
-            :raises taca_ngi_pipeline.utils.database.DatabaseError:
-                if an error occurred when communicating with the database
-            THIS HAS BEEN COPIED AND PASTED FROM deliver.py ProjectDeliverer class
-        """
-        return db.update_project(db.dbcon(), self.projectid, delivery_status=status)
 
     def deliver_project(self):
         """ Deliver all samples in a project to mosler
@@ -146,7 +104,7 @@ class MoslerProjectDeliverer(MoslerDeliverer):
 
 
 
-class MoslerSampleDeliverer(MoslerDeliverer):
+class MoslerSampleDeliverer(SampleDeliverer):
     """
         A class for handling sample deliveries to Mosler
     """
@@ -162,74 +120,6 @@ class MoslerSampleDeliverer(MoslerDeliverer):
     def deliver_sample_thread(self, sampleentry=None, result=None, index=None):
         result[index] = self.deliver_sample(sampleentry)
         return None
-
-    def deliver_sample(self, sampleentry=None):
-        """ Deliver a sample to the destination specified by the config.
-            Will check if the sample has already been delivered and should not
-            be delivered again or if the sample is not yet ready to be delivered.
-
-            :params sampleentry: a database sample entry to use for delivery,
-                be very careful with caching the database entries though since
-                concurrent processes can update the database at any time
-            :returns: True if sample was successfully delivered or was previously
-                delivered, False if sample was not yet ready to be delivered
-            :raises taca_ngi_pipeline.utils.database.DatabaseError: if an entry corresponding to this
-                sample could not be found in the database
-            :raises DelivererReplaceError: if a previous delivery of this sample
-                has taken place but should be replaced
-            :raises DelivererError: if the delivery failed
-            THIS HAS BEEN COPIED AND PASTED FROM deliver.py SampletDeliverer class
-        """
-        # propagate raised errors upwards, they should trigger notification to operator
-        try:
-            logger.info("Delivering {} to {}".format(
-                str(self), self.expand_path(self.deliverypath)))
-            try:
-                if self.get_analysis_status(sampleentry) != 'ANALYZED' \
-                        and not self.force:
-                    logger.info("{} has not finished analysis and will not be delivered".format(str(self)))
-                    return False
-                if self.get_delivery_status(sampleentry) == 'DELIVERED' \
-                        and not self.force:
-                    logger.info("{} has already been delivered".format(str(self)))
-                    return True
-                elif self.get_delivery_status(sampleentry) == 'IN_PROGRESS' \
-                        and not self.force:
-                    logger.info("delivery of {} is already in progress".format(
-                        str(self)))
-                    return False
-                elif self.get_delivery_status(sampleentry) == 'FAILED':
-                    logger.info("retrying delivery of previously failed sample {}".format(str(self)))
-            except db.DatabaseError as e:
-                logger.error(
-                    "error '{}' occurred during delivery of {}".format(
-                        str(e), str(self)))
-                raise
-            # set the delivery status to in_progress which will also mean that any concurrent deliveries
-            # will leave this sample alone
-            self.update_delivery_status(status="IN_PROGRESS")
-            #Skipping report generation for MOSLER.... I have more urgen problems right now....
-            # stage the delivery
-            if not self.stage_delivery():
-                raise DelivererError("sample was not properly staged")
-            logger.info("{} successfully staged".format(str(self)))
-            if not self.stage_only:
-                # perform the delivery
-                if not self.do_delivery():
-                    raise DelivererError("sample was not properly delivered")
-                logger.info("{} successfully delivered".format(str(self)))
-                # set the delivery status in database
-                self.update_delivery_status()
-                # write a delivery acknowledgement to disk
-                #self.acknowledge_delivery() # not sure what this does for now I silent you
-            return True
-        except DelivererInterruptedError:
-            self.update_delivery_status(status="NOT DELIVERED")
-            raise
-        except Exception:
-            self.update_delivery_status(status="FAILED")
-            raise
-
 
 
     def do_delivery(self):
@@ -265,28 +155,5 @@ class MoslerSampleDeliverer(MoslerDeliverer):
         self.sftp_client.close()
         # return True, if something went wrong an exception is thrown before this
         return True
-
-
-
-    def db_entry(self):
-        """ Fetch a database entry representing the instance's project and sample
-            :returns: a json-formatted database entry
-            :raises taca_ngi_pipeline.utils.database.DatabaseError:
-                if an error occurred when communicating with the database
-            THIS HAS BEEN COPIED AND PASTED FROM deliver.py SampletDeliverer class
-        """
-        return db.sample_entry(db.dbcon(), self.projectid, self.sampleid)
-
-    def update_delivery_status(self, status="DELIVERED"):
-        """ Update the delivery_status field in the database to the supplied 
-            status for the project and sample specified by this instance
-            :returns: the result from the underlying api call
-            :raises taca_ngi_pipeline.utils.database.DatabaseError:
-                if an error occurred when communicating with the database
-            THIS HAS BEEN COPIED AND PASTED FROM deliver.py SampletDeliverer class
-        """
-        return db.update_sample(db.dbcon(), self.projectid, self.sampleid, delivery_status=status)
-
-
 
 

--- a/taca_ngi_pipeline/deliver/deliver_mosler.py
+++ b/taca_ngi_pipeline/deliver/deliver_mosler.py
@@ -1,0 +1,99 @@
+""" 
+    Module for controlling deliveries os samples and projects to Mosler (THE MOSLER!!!!)
+"""
+
+
+
+from deliver import *
+
+
+class ProjectDeliverer(ProjectDeliverer):
+    """ This object takes care of delivering project samples to mosler.
+        When delivering to Mosler the delivery can take place only at project level
+    """
+    def __init__(self, projectid=None, sampleid=None, **kwargs):
+        super(ProjectDeliverer, self).__init__(
+            projectid,
+            sampleid,
+            **kwargs)
+
+    def deliver_project(self):
+        """ Deliver all samples in a project to mosler
+            
+            :returns: True if all samples were delivered successfully, False if
+                any sample was not properly delivered or ready to be delivered
+        """
+        import pdb
+        pdb.set_trace()
+        try:
+            logger.info("Delivering {} to {}".format(
+                str(self), self.expand_path(self.deliverypath)))
+            if self.get_delivery_status() == 'DELIVERED' \
+                    and not self.force:
+                logger.info("{} has already been delivered".format(str(self)))
+                return True
+            # right now, don't catch any errors since we're assuming any thrown 
+            # errors needs to be handled by manual intervention
+            status = True
+            for sampleid in [sentry['sampleid'] for sentry in db.project_sample_entries(
+                    db.dbcon(), self.projectid).get('samples', [])]:
+                st = SampleDeliverer(self.projectid, sampleid).deliver_sample()
+                status = (status and st)
+            # query the database whether all samples in the project have been sucessfully delivered
+            if self.all_samples_delivered():
+                # this is the only delivery status we want to set on the project level, in order to avoid concurrently
+                # running deliveries messing with each other's status updates
+                self.update_delivery_status(status="DELIVERED")
+                self.acknowledge_delivery()
+                # create the final aggregate report
+                try:
+                    if self.report_aggregate:
+                        logger.info("creating final aggregate report")
+                        self.create_report()
+                except AttributeError as e:
+                    pass
+                except Exception as e:
+                    logger.warning(
+                        "failed to create final aggregate report for {}, "\
+                        "reason: {}".format(self,e))
+            return status
+        except (db.DatabaseError, DelivererInterruptedError, Exception):
+            raise
+
+    def expand_path(self, path):
+        """ Will set the delivery path on mosler sftp server
+            which is /UPPMAXID
+            
+            :params string path: the path to expand
+            :returns: the supplied path will all placeholders substituted with
+                the corresponding instance attributes
+            :raises DelivererError: if a corresponding attribute for a 
+                placeholder could not be found
+        """
+        path = "/{}".format(self.uppnexid)
+        return path
+
+
+
+class SampleDeliverer(SampleDeliverer):
+
+
+
+    def do_delivery(self):
+        """ Deliver the staged delivery folder using sftp
+            :returns: True if delivery was successful, False if unsuccessful
+            :raises DelivererTOBEDEFINEDError: if an exception occurred during
+                transfer
+        """
+        #tar sample directory
+        #transfer it (maybe an open session is needed)
+        import pdb
+        pdb.set_trace()
+        #delete the tar
+
+
+
+
+
+
+

--- a/taca_ngi_pipeline/deliver/deliver_mosler.py
+++ b/taca_ngi_pipeline/deliver/deliver_mosler.py
@@ -2,7 +2,7 @@
     Module for controlling deliveries os samples and projects to Mosler (THE MOSLER!!!!)
 """
 
-
+import paramiko
 
 from deliver import *
 
@@ -52,6 +52,8 @@ class MoslerProjectDeliverer(MoslerDeliverer):
                 any sample was not properly delivered or ready to be delivered
         """
 
+        ### TODO: I need to open here an sft connection
+
         try:
             logger.info("Delivering {} to {}".format(
                 str(self), self.expand_path(self.moslerdeliverypath)))
@@ -69,6 +71,8 @@ class MoslerProjectDeliverer(MoslerDeliverer):
                 st = MoslerSampleDeliverer(self.projectid, sampleid).deliver_sample()
                 status = (status and st)
             # query the database whether all samples in the project have been sucessfully delivered
+            import pdb
+            pdb.set_trace()
             if self.all_samples_delivered():
                 # this is the only delivery status we want to set on the project level, in order to avoid concurrently
                 # running deliveries messing with each other's status updates
@@ -191,8 +195,35 @@ class MoslerSampleDeliverer(MoslerDeliverer):
                 transfer
         """
         #tar sample directory
-        #transfer it (maybe an open session is needed)
+        #stolen from http://stackoverflow.com/questions/2032403/how-to-create-full-compressed-tar-file-using-python
+        #import tarfile
+        #tar = tarfile.open("sample.tar.gz", "w:gz")
+        #for name in ["file1", "file2", "file3"]:
+        #    tar.add(name)
+        #tar.close()
         
+        #transfer it (maybe an open session is needed)
+        import pdb
+        pdb.set_trace()
+        host = "mosler.bils.se"
+        try:
+            transport=paramiko.Transport(host)
+            try:
+                password=str(raw_input('Mosler Password:'))
+            except ValueError:
+                print "Not a string"
+            import pdb
+            pdb.set_trace()
+            transport.connect(username = "vezzi", password = password)
+            sftp_client = transport.open_sftp_client()
+            #move to the delivery directory
+            sftp_client.chdir("bils2016002")
+            
+            sftp.put('/home/vezzi/software/taca-ngi-pipeline/requirements.txt', 'requirments.txt')
+            
+            sftp_client.close()
+            transport.close()
+
         import pdb
         pdb.set_trace()
         #delete the tar

--- a/taca_ngi_pipeline/deliver/deliver_mosler.py
+++ b/taca_ngi_pipeline/deliver/deliver_mosler.py
@@ -6,16 +6,44 @@
 
 from deliver import *
 
+class MoslerDeliverer(Deliverer):
 
-class ProjectDeliverer(ProjectDeliverer):
+    def __init__(self, projectid=None, sampleid=None, **kwargs):
+        super(MoslerDeliverer, self).__init__(
+            projectid,
+            sampleid,
+            **kwargs)
+        self.moslerdeliverypath = getattr(self, 'moslerdeliverypath', None)
+
+
+class MoslerProjectDeliverer(MoslerDeliverer):
     """ This object takes care of delivering project samples to mosler.
         When delivering to Mosler the delivery can take place only at project level
     """
     def __init__(self, projectid=None, sampleid=None, **kwargs):
-        super(ProjectDeliverer, self).__init__(
+        super(MoslerProjectDeliverer, self).__init__(
             projectid,
             sampleid,
             **kwargs)
+    
+    def db_entry(self):
+        """ Fetch a database entry representing the instance's project
+            :returns: a json-formatted database entry
+            :raises taca_ngi_pipeline.utils.database.DatabaseError:
+                if an error occurred when communicating with the database
+            THIS HAS BEEN COPIED AND PASTED FROM deliver.py ProjectDeliverer class
+        """
+        return db.project_entry(db.dbcon(), self.projectid)
+    
+    def update_delivery_status(self, status="DELIVERED"):
+        """ Update the delivery_status field in the database to the supplied 
+            status for the project specified by this instance
+            :returns: the result from the underlying api call
+            :raises taca_ngi_pipeline.utils.database.DatabaseError:
+                if an error occurred when communicating with the database
+            THIS HAS BEEN COPIED AND PASTED FROM deliver.py ProjectDeliverer class
+        """
+        return db.update_project(db.dbcon(), self.projectid, delivery_status=status)
 
     def deliver_project(self):
         """ Deliver all samples in a project to mosler
@@ -23,11 +51,10 @@ class ProjectDeliverer(ProjectDeliverer):
             :returns: True if all samples were delivered successfully, False if
                 any sample was not properly delivered or ready to be delivered
         """
-        import pdb
-        pdb.set_trace()
+
         try:
             logger.info("Delivering {} to {}".format(
-                str(self), self.expand_path(self.deliverypath)))
+                str(self), self.expand_path(self.moslerdeliverypath)))
             if self.get_delivery_status() == 'DELIVERED' \
                     and not self.force:
                 logger.info("{} has already been delivered".format(str(self)))
@@ -37,7 +64,9 @@ class ProjectDeliverer(ProjectDeliverer):
             status = True
             for sampleid in [sentry['sampleid'] for sentry in db.project_sample_entries(
                     db.dbcon(), self.projectid).get('samples', [])]:
-                st = SampleDeliverer(self.projectid, sampleid).deliver_sample()
+                import pdb
+                pdb.set_trace()
+                st = MoslerSampleDeliverer(self.projectid, sampleid).deliver_sample()
                 status = (status and st)
             # query the database whether all samples in the project have been sucessfully delivered
             if self.all_samples_delivered():
@@ -60,22 +89,98 @@ class ProjectDeliverer(ProjectDeliverer):
         except (db.DatabaseError, DelivererInterruptedError, Exception):
             raise
 
-    def expand_path(self, path):
-        """ Will set the delivery path on mosler sftp server
-            which is /UPPMAXID
-            
-            :params string path: the path to expand
-            :returns: the supplied path will all placeholders substituted with
-                the corresponding instance attributes
-            :raises DelivererError: if a corresponding attribute for a 
-                placeholder could not be found
+
+
+
+
+class MoslerSampleDeliverer(MoslerDeliverer):
+    """
+        A class for handling sample deliveries to Mosler
+    """
+
+    def __init__(self, projectid=None, sampleid=None, **kwargs):
+        super(MoslerSampleDeliverer, self).__init__(
+            projectid,
+            sampleid,
+            **kwargs)
+
+    def deliver_sample(self, sampleentry=None):
+        """ Deliver a sample to the destination specified by the config.
+            Will check if the sample has already been delivered and should not
+            be delivered again or if the sample is not yet ready to be delivered.
+
+            :params sampleentry: a database sample entry to use for delivery,
+                be very careful with caching the database entries though since
+                concurrent processes can update the database at any time
+            :returns: True if sample was successfully delivered or was previously
+                delivered, False if sample was not yet ready to be delivered
+            :raises taca_ngi_pipeline.utils.database.DatabaseError: if an entry corresponding to this
+                sample could not be found in the database
+            :raises DelivererReplaceError: if a previous delivery of this sample
+                has taken place but should be replaced
+            :raises DelivererError: if the delivery failed
+            THIS HAS BEEN COPIED AND PASTED FROM deliver.py SampletDeliverer class
         """
-        path = "/{}".format(self.uppnexid)
-        return path
-
-
-
-class SampleDeliverer(SampleDeliverer):
+        # propagate raised errors upwards, they should trigger notification to operator
+        try:
+            logger.info("Delivering {} to {}".format(
+                str(self), self.expand_path(self.deliverypath)))
+            try:
+                if self.get_analysis_status(sampleentry) != 'ANALYZED' \
+                        and not self.force:
+                    logger.info("{} has not finished analysis and will not be delivered".format(str(self)))
+                    return False
+                if self.get_delivery_status(sampleentry) == 'DELIVERED' \
+                        and not self.force:
+                    logger.info("{} has already been delivered".format(str(self)))
+                    return True
+                elif self.get_delivery_status(sampleentry) == 'IN_PROGRESS' \
+                        and not self.force:
+                    logger.info("delivery of {} is already in progress".format(
+                        str(self)))
+                    return False
+                elif self.get_delivery_status(sampleentry) == 'FAILED':
+                    logger.info("retrying delivery of previously failed sample {}".format(str(self)))
+            except db.DatabaseError as e:
+                logger.error(
+                    "error '{}' occurred during delivery of {}".format(
+                        str(e), str(self)))
+                raise
+            # set the delivery status to in_progress which will also mean that any concurrent deliveries
+            # will leave this sample alone
+            self.update_delivery_status(status="IN_PROGRESS")
+            # an error with the reports should not abort the delivery, so handle
+            #Skipping report generation for MOSLER.... I have more urgen problems right now....
+            #try:
+            #    if self.report_sample and self.report_aggregate:
+            #        logger.info("creating sample reports")
+            #        self.create_report()
+            #except AttributeError:
+            #    pass
+            #except Exception as e:
+            #    logger.warning(
+            #        "failed to create reports for {}, reason: {}".format(
+            #            self, e))
+            # stage the delivery
+            if not self.stage_delivery():
+                raise DelivererError("sample was not properly staged")
+            logger.info("{} successfully staged".format(str(self)))
+            if not self.stage_only:
+                # perform the delivery
+                if not self.do_delivery():
+                    raise DelivererError("sample was not properly delivered")
+                logger.info("{} successfully delivered".format(str(self)))
+                # set the delivery status in database
+                self.update_delivery_status()
+                # write a delivery acknowledgement to disk
+                self.acknowledge_delivery()
+            return True
+        except DelivererInterruptedError:
+            self.update_delivery_status(status="NOT DELIVERED")
+            raise
+        except Exception:
+            self.update_delivery_status(status="FAILED")
+            raise
 
 
 
@@ -87,12 +192,29 @@ class SampleDeliverer(SampleDeliverer):
         """
         #tar sample directory
         #transfer it (maybe an open session is needed)
+        
         import pdb
         pdb.set_trace()
         #delete the tar
 
+    def db_entry(self):
+        """ Fetch a database entry representing the instance's project and sample
+            :returns: a json-formatted database entry
+            :raises taca_ngi_pipeline.utils.database.DatabaseError:
+                if an error occurred when communicating with the database
+            THIS HAS BEEN COPIED AND PASTED FROM deliver.py SampletDeliverer class
+        """
+        return db.sample_entry(db.dbcon(), self.projectid, self.sampleid)
 
-
+    def update_delivery_status(self, status="DELIVERED"):
+        """ Update the delivery_status field in the database to the supplied 
+            status for the project and sample specified by this instance
+            :returns: the result from the underlying api call
+            :raises taca_ngi_pipeline.utils.database.DatabaseError:
+                if an error occurred when communicating with the database
+            THIS HAS BEEN COPIED AND PASTED FROM deliver.py SampletDeliverer class
+        """
+        return db.update_sample(db.dbcon(), self.projectid, self.sampleid, delivery_status=status)
 
 
 


### PR DESCRIPTION
Command to be run looks like:
 `taca -c ~/.taca/taca.deliver.sthlm.v2.yaml deliver --force --uppnexid bils2016002  mosler P2262`
The following fields need to be added to the config file:
```
    moslerdeliverypath: /<UPPNEXID>  
    moslersftpserver: mosler.bils.se
    moslersftpserver_user: vezzi  #mosler username (same of milou, nestor)
    moslersftpmaxfiles: 9 # max number of files that can be present on mosler sftp server 
```

The script does the following:
 - stage the delivery
 - compute checksums 
 - tar ball the sample dir
 - move the tar to mosler sftp server

the password and token auth need to be entered only once. The person need to be a member of the mosler project.
For now the limiting factor is the delivery time. Last test I performed a delivery took 100 minutes. However there are too many "limiting" factors:
 - tar-balling on nestor is extremely slow and cannot be multi-threaded (can be but I kill the system)
 - moving at the same time more than one sample saturate the bandwith... but I need to test this out

For now reports are not generated. Delivery to mosler should be a one time thing... so we can generate them independently and send them at once. Also checking the success of the transfer...  I want to do it but need to think a bit more about it (the success corresponds to the file disappearing from mosler sftp... which can happen at any time...)

It is better to fist stage and compute the checksums, and then delivery, in this way the deliveries of samples should start in a quicker way.  But again this needs to be tested on irma, where performances should improve a lot.

It is unclear if we will deliver with this solution or with something else, but for now this is stable enough to have and I do not want to develop more until Irma is fully in place and we know how we will deliver things.

@b97pla 


