### PR TITLE
WIP: Copy project report to outbox

### DIFF
--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -412,7 +412,7 @@ class ProjectDeliverer(Deliverer):
                 except Exception as e:
                     logger.warning(
                         "failed to create final aggregate report for {}, "\
-                        "reason: {}".format(self,e))
+                        "reason: {}".format(self, e))
 
                 try:
                     if self.copy_reports_to_reports_outbox:

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -359,11 +359,11 @@ class ProjectDeliverer(Deliverer):
             files_copied.append(version_report_file_target)
 
         except AssertionError as e:
-            logger.error("Had trouble parsing reports from `files_to_deliver` in config.")
-            logger.error(e.message)
+            logger.warning("Had trouble parsing reports from `files_to_deliver` in config.")
+            logger.warning(e.message)
         except KeyError as e:
-            logger.error("Could not find specified value in config: {}."
-                         "Will not be able to copy the report.".format(e.message))
+            logger.warning("Could not find specified value in config: {}."
+                           "Will not be able to copy the report.".format(e.message))
 
         return files_copied
 

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -339,7 +339,8 @@ class ProjectDeliverer(Deliverer):
                 return matches[0]
 
         def create_target_path(target_file_name):
-            return self.expand_path(os.path.join(self.config["reports_outbox"], os.path.basename(target_file_name)))
+            reports_outbox = self.config["reports_outbox"]
+            return self.expand_path(os.path.join(reports_outbox, os.path.basename(target_file_name)))
 
         files_copied = []
         try:
@@ -358,6 +359,9 @@ class ProjectDeliverer(Deliverer):
         except AssertionError as e:
             logger.error("Had trouble parsing reports from `files_to_deliver` in config.")
             logger.error(e.message)
+        except KeyError as e:
+            logger.error("Could not find specified value in config: {}."
+                         "Will not be able to copy the report.".format(e.message))
 
         return files_copied
 

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -330,7 +330,9 @@ class ProjectDeliverer(Deliverer):
 
             for file_list in self.files_to_deliver:
                 for f in file_list:
-                    if re.match(pattern, f):
+                    # Check that type is string, since list might also contain
+                    # objects
+                    if type(f) is str and re.match(pattern, f):
                         matches.append(f)
 
             if not matches or len(matches) != 1:
@@ -405,15 +407,20 @@ class ProjectDeliverer(Deliverer):
                     if self.report_aggregate:
                         logger.info("creating final aggregate report")
                         self.create_report()
-                    if self.copy_reports_to_reports_outbox:
-                        logger.info("copying reports to report outbox")
-                        self.copy_report()
                 except AttributeError as e:
                     pass
                 except Exception as e:
                     logger.warning(
                         "failed to create final aggregate report for {}, "\
                         "reason: {}".format(self,e))
+
+                try:
+                    if self.copy_reports_to_reports_outbox:
+                        logger.info("copying reports to report outbox")
+                        self.copy_report()
+                except Exception as e:
+                    logger.warning("failed to copy report to report outbox, with reason: {}".format(e.message))
+
             return status
         except (db.DatabaseError, DelivererInterruptedError, Exception):
             raise

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -411,6 +411,7 @@ class ProjectDeliverer(Deliverer):
                     logger.warning(
                         "failed to create final aggregate report for {}, "\
                         "reason: {}".format(self, e))
+                    raise e
 
                 try:
                     if self.copy_reports_to_reports_outbox:

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -400,8 +400,6 @@ class ProjectDeliverer(Deliverer):
             if self.all_samples_delivered():
                 # this is the only delivery status we want to set on the project level, in order to avoid concurrently
                 # running deliveries messing with each other's status updates
-                self.update_delivery_status(status="DELIVERED")
-                self.acknowledge_delivery()
                 # create the final aggregate report
                 try:
                     if self.report_aggregate:
@@ -420,6 +418,9 @@ class ProjectDeliverer(Deliverer):
                         self.copy_report()
                 except Exception as e:
                     logger.warning("failed to copy report to report outbox, with reason: {}".format(e.message))
+
+                self.update_delivery_status(status="DELIVERED")
+                self.acknowledge_delivery()
 
             return status
         except (db.DatabaseError, DelivererInterruptedError, Exception):

--- a/tests/data/taca_test_cfg.yaml
+++ b/tests/data/taca_test_cfg.yaml
@@ -9,6 +9,8 @@ deliver:
     report_aggregate: ngi_reports ign_aggregate_report -n uppsala --pandoc_binary
     report_sample: ngi_reports ign_sample_report -n uppsala --pandoc_binary
     reportpath: <ANALYSISPATH>/piper_ngi
+    copy_reports_to_reports_outbox: True
+    reports_outbox: /test/this/path
     logpath: <REPORTPATH>/logs
     deliverystatuspath: <REPORTPATH>/08_misc
     operator: operator@domain.com

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -50,7 +50,7 @@ SAMPLECFG = {
             ['<DATAPATH>/level1_folder1/level1_folder1_file1.md5',
              '<STAGINGPATH>'],
             ['<DATAPATH>/level1_folder1/level2_folder1/this_aggregate_report.csv',
-             '<STAGINGPATH>'],
+             '<STAGINGPATH>', {'no_digest_cache': True, 'required': True}],
             ['<DATAPATH>/level1_folder1/level2_folder1/version_report.txt',
              '<STAGINGPATH>'],
         ]}}


### PR DESCRIPTION
This is a work in progress, please do not merge untils it's ready. I'm pushing it here to get some feedback at this point.

This introduces a change into the delivery script which will copy the aggregate report and version report to  a specified directory when they are generated. This reason we want to do this is so that we can rsync them down from irma - which is only possible from specific directories.

It will only carry out the copying provided that `copy_reports_to_reports_outbox` is set to `True` in the config. It also requires that `reports_outbox` is specified.

Still to do before this is finished is:
 - [x] testing outside of unit tests

I'd like to hear what e.g. @b97pla thinks of this.
