### PR TITLE
Taca-ngi-pipeline now supports projectname argument in recipe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
     - mkdir /home/travis/.ngipipeline
     - "echo foo: bar > /home/travis/.ngipipeline/ngi_config.yaml"
     - pip install setuptools --upgrade
+    - pip install pyexcel
 install:
     - python setup.py install
 

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -87,13 +87,17 @@ class Deliverer(object):
         self.reportpath = getattr(self, 'reportpath', None)
         self.force = getattr(self, 'force', False)
         self.stage_only = getattr(self, 'stage_only', False)
+        #Fetches a project name, should always be availble; but is not a requirement
+        try:
+            self.projectname = db.project_entry(db.dbcon(), projectid)['name']
+        except KeyError:
+            pass
         # only set an attribute for uppnexid if it's actually given or in the db
         try:
             getattr(self, 'uppnexid')
         except AttributeError:
             try:
-                t = db.project_entry(db.dbcon(), projectid)['uppnex_id']
-                self.uppnexid = t
+                self.uppnexid = db.project_entry(db.dbcon(), projectid)['uppnex_id']
             except KeyError:
                 pass
         # set a custom signal handler to intercept interruptions

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -628,16 +628,19 @@ class TestSampleDeliverer(unittest.TestCase):
             uppnexid="this-is-the-uppnexid",
             **SAMPLECFG['deliver'])
         self.assertEquals(deliverer.uppnexid, "this-is-the-uppnexid")
-        self.assertFalse(dbmock.called,
-                         "the database should not have been queried")
+        #called once due to projectname
+        dbmock.assert_called_once_with(self.projectid)
         # if an uppnexid is not supplied in the config, the database should be consulted
+        dbmock.reset_mock()
+        prior = dbmock.call_count
         deliverer = deliver.SampleDeliverer(
             self.projectid,
             self.sampleid,
             rootdir=self.casedir,
             **SAMPLECFG['deliver'])
         self.assertEquals(deliverer.uppnexid, PROJECTENTRY['uppnex_id'])
-        dbmock.assert_called_once_with(self.projectid)
+        #two calls, one for projectname one for uppnexid
+        self.assertEquals(dbmock.call_count, 2)
 
     @mock.patch.object(
         deliver.db.db.CharonSession,


### PR DESCRIPTION
Also fixed the commit history, since PRs ended up being a TravisCI check.