### PR TITLE
New TACA mover version

### DIFF
--- a/taca_ngi_pipeline/cli.py
+++ b/taca_ngi_pipeline/cli.py
@@ -82,7 +82,7 @@ def deliver(ctx, deliverypath, stagingpath, uppnexid, operator, stage_only, forc
               help='flag to specify if data contained in the project is sensitive or not')
 @click.option('--hard-stage-only',
               is_flag=True,
-			  default = False,
+              default = False,
               help='Perform all the delivery actions but does not run to_mover (to be used for semi-manual deliveries)')
 
 def project(ctx, projectid, snic_api_credentials=None, statusdb_config=None, order_portal=None, pi_email=None, sensitive=True, hard_stage_only=False):

--- a/taca_ngi_pipeline/cli.py
+++ b/taca_ngi_pipeline/cli.py
@@ -80,8 +80,12 @@ def deliver(ctx, deliverypath, stagingpath, uppnexid, operator, stage_only, forc
 @click.option('--sensitive/--no-sensitive',
 			  default = True,
               help='flag to specify if data contained in the project is sensitive or not')
+@click.option('--hard-stage-only',
+              is_flag=True,
+			  default = False,
+              help='Perform all the delivery actions but does not run to_mover (to be used for semi-manual deliveries)')
 
-def project(ctx, projectid, snic_api_credentials=None, statusdb_config=None, order_portal=None, pi_email=None, sensitive=True):
+def project(ctx, projectid, snic_api_credentials=None, statusdb_config=None, order_portal=None, pi_email=None, sensitive=True, hard_stage_only=False):
     """ Deliver the specified projects to the specified destination
     """
     if ctx.parent.params['cluster'] == 'bianca':
@@ -118,6 +122,7 @@ def project(ctx, projectid, snic_api_credentials=None, statusdb_config=None, ord
                 projectid=pid,
                 pi_email=pi_email,
                 sensitive=sensitive,
+                hard_stage_only=hard_stage_only,
                 **ctx.parent.params)
         _exec_fn(d, d.deliver_project)
 

--- a/taca_ngi_pipeline/cli.py
+++ b/taca_ngi_pipeline/cli.py
@@ -59,31 +59,31 @@ def deliver(ctx, deliverypath, stagingpath, uppnexid, operator, stage_only, forc
 @click.pass_context
 @click.argument('projectid', type=click.STRING, nargs=-1)
 @click.option('--snic-api-credentials',
-			  default=None,
-			  envvar='SNIC_API_STOCKHOLM',
-			  type=click.File('r'),
-			  help='Path to SNIC-API credentials to create delivery projects')
+            default=None,
+            envvar='SNIC_API_STOCKHOLM',
+            type=click.File('r'),
+            help='Path to SNIC-API credentials to create delivery projects')
 @click.option('--statusdb-config',
-			  default=None,
-			  envvar='STATUS_DB_CONFIG',
-			  type=click.File('r'),
-			  help='Path to statusdb-configuration')
+            default=None,
+            envvar='STATUS_DB_CONFIG',
+            type=click.File('r'),
+            help='Path to statusdb-configuration')
 @click.option('--order-portal',
-			  default=None,
-			  envvar='ORDER_PORTAL',
-			  type=click.File('r'),
-			  help='Path to order portal credantials to retrive PI email')
+            default=None,
+            envvar='ORDER_PORTAL',
+            type=click.File('r'),
+            help='Path to order portal credantials to retrive PI email')
 @click.option('--pi-email',
-			  default=None,
-			  type=click.STRING,
-			  help='pi-email, to be specified if PI-email stored in statusdb does not correspond SUPR PI-email')
+            default=None,
+            type=click.STRING,
+            help='pi-email, to be specified if PI-email stored in statusdb does not correspond SUPR PI-email')
 @click.option('--sensitive/--no-sensitive',
-			  default = True,
-              help='flag to specify if data contained in the project is sensitive or not')
+            default = True,
+            help='flag to specify if data contained in the project is sensitive or not')
 @click.option('--hard-stage-only',
-              is_flag=True,
-              default = False,
-              help='Perform all the delivery actions but does not run to_mover (to be used for semi-manual deliveries)')
+            is_flag=True,
+            default = False,
+            help='Perform all the delivery actions but does not run to_mover (to be used for semi-manual deliveries)')
 
 def project(ctx, projectid, snic_api_credentials=None, statusdb_config=None, order_portal=None, pi_email=None, sensitive=True, hard_stage_only=False):
     """ Deliver the specified projects to the specified destination

--- a/taca_ngi_pipeline/cli.py
+++ b/taca_ngi_pipeline/cli.py
@@ -68,6 +68,11 @@ def deliver(ctx, deliverypath, stagingpath, uppnexid, operator, stage_only, forc
 			  envvar='STATUS_DB_CONFIG',
 			  type=click.File('r'),
 			  help='Path to statusdb-configuration')
+@click.option('--order-portal',
+			  default=None,
+			  envvar='ORDER_PORTAL',
+			  type=click.File('r'),
+			  help='Path to order portal credantials to retrive PI email')
 @click.option('--pi-email',
 			  default=None,
 			  type=click.STRING,
@@ -76,7 +81,7 @@ def deliver(ctx, deliverypath, stagingpath, uppnexid, operator, stage_only, forc
 			  default = True,
               help='flag to specify if data contained in the project is sensitive or not')
 
-def project(ctx, projectid, snic_api_credentials=None, statusdb_config=None, pi_email=None, sensitive=True):
+def project(ctx, projectid, snic_api_credentials=None, statusdb_config=None, order_portal=None, pi_email=None, sensitive=True):
     """ Deliver the specified projects to the specified destination
     """
     if ctx.parent.params['cluster'] == 'bianca':
@@ -105,6 +110,10 @@ def project(ctx, projectid, snic_api_credentials=None, statusdb_config=None, pi_
                 logger.error("--snic-api-credentials or env variable $SNIC_API_STOCKHOLM need to be set to perform GRUS delivery")
                 return 1
             taca.utils.config.load_yaml_config(snic_api_credentials)
+            if order_portal == None:
+                logger.error("--order-portal or env variable $ORDER_PORTAL need to be set to perform GRUS delivery")
+                return 1
+            taca.utils.config.load_yaml_config(order_portal)
             d = _deliver_grus.GrusProjectDeliverer(
                 projectid=pid,
                 pi_email=pi_email,

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -552,7 +552,7 @@ class SampleDeliverer(Deliverer):
                     #set it to delivered as ABORTED samples should not fail the status of a project
                     if  self.get_delivery_status(sampleentry):
                         #if status is set, then overwrite it to NOT_DELIVERED
-                        self.update_delivery_status(status="NOT DELIVERED")
+                        self.update_delivery_status(status="NOT_DELIVERED")
                     #otherwhise leave it empty. Return True as an aborted sample should not fail a delivery
                     return True
                 if self.get_sample_status(sampleentry) == 'FRESH' \
@@ -597,7 +597,7 @@ class SampleDeliverer(Deliverer):
                 self.update_delivery_status(status="STAGED")
             return True
         except DelivererInterruptedError:
-            self.update_delivery_status(status="NOT DELIVERED")
+            self.update_delivery_status(status="NOT_DELIVERED")
             raise
         except Exception:
             self.update_delivery_status(status="FAILED")

--- a/taca_ngi_pipeline/deliver/deliver_grus.py
+++ b/taca_ngi_pipeline/deliver/deliver_grus.py
@@ -458,9 +458,6 @@ class GrusProjectDeliverer(ProjectDeliverer):
         password = self.config_statusdb.get('password')
         port     = self.config_statusdb.get('port')
         status_db_url = 'http://{}:{}@{}:{}'.format(username, password, url, port)
-        import pdb
-        pdb.set_trace()
-        
         status_db = couchdb.Server(status_db_url)
         projects_db = status_db['projects']
         view = projects_db.view('order_portal/ProjectID_to_PortalID')
@@ -474,23 +471,9 @@ class GrusProjectDeliverer(ProjectDeliverer):
         get_project_url = '{}/v1/order/{}'.format(self.orderportal.get('orderportal_api_url'), portal_id)
         headers = {'X-OrderPortal-API-key': '{}'.format(self.orderportal.get('orderportal_api_token'))}
         response = requests.get(get_project_url, headers=headers)
-        response.status_code  #this returns 200 perfect
-        json.dumps(response.json(), indent=2)
         if response.status_code != 200:
             raise AssertionError("Status code returned when trying to get PI email from project in order portal: {} was not 200. Response was: {}".format(portal_id, response.content))
-        import pdb
-        pdb.set_trace()
-        result = json.loads(response.content)
-        
-        #orderportal_db = status_db['orderportal_ngi']
-        #view = orderportal_db.view('taca/project_id_to_pi_email')
-        #rows = view[self.projectid].rows
-        #if len(rows) < 1:
-        #    raise AssertionError("Project {} not found in StatusDB: {}".format(self.projecid, url))
-        #if len(rows) > 1:
-        #    raise AssertionError('Project {} has more than one entry in orderportal_db'.format(self.projectid))
-        #
-        #pi_email = rows[0].value
+        pi_email = json.loads(response.content)['fields']['project_pi_email']
         return pi_email
 
 

--- a/taca_ngi_pipeline/deliver/deliver_grus.py
+++ b/taca_ngi_pipeline/deliver/deliver_grus.py
@@ -70,8 +70,8 @@ class GrusProjectDeliverer(ProjectDeliverer):
             raise AttributeError("snic confoguration is needed  delivering to GRUS (snic_api_url, snic_api_user, snic_api_password")
         self.config_statusdb = CONFIG.get('statusdb',None)
         if self.config_statusdb is None:
-            raise AttributeError("statusdc configuration is needed  delivering to GRUS (url, username, password, port")
-        self.orderportal = CONFIG.get('order_portal',None) # do not need to raise expection here, I have already checked for this and monitoring does not need it
+            raise AttributeError("statusdb configuration is needed  delivering to GRUS (url, username, password, port")
+        self.orderportal = CONFIG.get('order_portal',None) # do not need to raise exception here, I have already checked for this and monitoring does not need it
         self.pi_email  = pi_email
         self.sensitive = sensitive
         self.hard_stage_only = hard_stage_only
@@ -97,7 +97,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
         return 'NOT_DELIVERED' #last possible case is that the project is not delivered
 
     def check_mover_delivery_status(self):
-        """ This functions checks is project is under delivery. If so it waits until projects is delivered or a certain threshold is met
+        """ This function checks is project is under delivery. If so it waits until projects is delivered or a certain threshold is met
         """
         #first thing check that we are using mover 1.0.0
         if not check_mover_version():


### PR DESCRIPTION
After the first test, did the following changes:

 - PI email is now fetched using order_portal API. The PID is used to retrieve the portalID and this is used to query the API for the PI-email 
 - Many sanity checks have been moved before the copy of files, in this way we should be able to catch failures earlier (without waiting the copy of large amounts of data)
 - status of not delivered changed to `NOT_DELIVERED`
 - mover version is checked and delivery is attempted only if version 1.0.0 is loaded
 - modified parsing of return values from mover to adapt it to version 1.0.0

For query new API the following is needed:
 
- mover/1.0.0 needs to be loaded by default by funk_006 `module load mover/1.0.0`
- new view in statusdb named `order_portal/ProjectID_to_PortalID`: 
```
function(doc) {
     emit(doc.project_id, doc.details.portal_id)
}
```

 - new configuration file in IRMA and new env variable `$ORDER_PORTAL` pointing to a file looking like:
```
order_portal:
    orderportal_api_url: 'http://ngisweden.scilifelab.se/api'
    orderportal_api_token: XXXXXXXXXXXXXXXX
```