### PR TITLE
TACA deliver updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ target/
 
 # PyCharm
 .idea/
+
+#Mac OS stuff
+.DS_Store*

--- a/taca_ngi_pipeline/__init__.py
+++ b/taca_ngi_pipeline/__init__.py
@@ -1,4 +1,4 @@
 """ Main taca_ngi_pipeline module
 """
 
-__version__ = '0.7.2'
+__version__ = '0.7.3'

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -502,10 +502,12 @@ class ProjectDeliverer(Deliverer):
                 sample_deliver.save_meta_info = False
                 st = sample_deliver.deliver_sample()
                 status = (status and st)
-            # Try to deliver any miscellaneous files for the project (like reports, analysis)
-            self.deliver_misc_data()
-            # Try aggregate and save meta info in database
-            self.aggregate_meta_info()
+            # Atleast one sample should have been staged/delivered for the following steps
+            if os.path.exists(self.expand_path(self.stagingpath)):
+                # Try to deliver any miscellaneous files for the project (like reports, analysis)
+                self.deliver_misc_data()
+                # Try aggregate and save meta info in database
+                self.aggregate_meta_info()
             # query the database whether all samples in the project have been sucessfully delivered
             if self.all_samples_delivered():
                 # this is the only delivery status we want to set on the project level, in order to avoid concurrently

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -300,7 +300,6 @@ class ProjectDeliverer(Deliverer):
             projectid,
             sampleid,
             **kwargs)
-        import pdb; pdb.set_trace()
 
     def all_samples_delivered(
             self,
@@ -468,6 +467,8 @@ class ProjectDeliverer(Deliverer):
             But error during copying of staged folder should be raised
         """
         misc_files_to_deliver = getattr(self, 'misc_files_to_deliver', [])
+        if len(misc_files_to_deliver) == 0:
+            return
         misc_gathered_files = fs.gather_files([map(self.expand_path, file_pattern) for file_pattern in misc_files_to_deliver],
                                                    no_checksum=self.no_checksum,
                                                    hash_algorithm=self.hash_algorithm)
@@ -514,9 +515,10 @@ class ProjectDeliverer(Deliverer):
                             '--exclude': ["*rsync.out", "*rsync.err"]
                         })
             try:
-                return ragent.transfer(transfer_log=self.transfer_log())
+                ragent.transfer(transfer_log=self.transfer_log())
             except transfer.TransferError as e:
                 raise DelivererRsyncError(e)
+        return
 
 class SampleDeliverer(Deliverer):
     """


### PR DESCRIPTION
This **PR** mainly addresses the following issues

- `GRUS` delivery related (include reports while hard staging, be able to deliver multiple projects to same delivery project)
- Non redundant way to deliver *miscellaneous* files
- Save the meta info for delivered files to `StatusDB` *(NGI Stockholm related)*

I will explain them in details in new comments (one for each issue) for more readability 😅  Of course can be discussed further along the review

**EDIT:** They are already tested to some extent and it works as intended 👍 