### PR TITLE
Update metainfo to statusdb

### DIFF
--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -335,11 +335,6 @@ class Deliverer(object):
         try:
             with open(os.getenv('STATUS_DB_CONFIG'), 'r') as db_cred_file:
                 db_conf = yaml.load(db_cred_file)['statusdb']
-        except Exception as e:
-            logger.warning("Reading DB config failed due to {}. Meta info will not be saved".format(e))
-            return False
-        # Upload metainfo to couchdb, if fails just move on
-        try:
             sdb = db.statusdb_session(db_conf, db="projects")
             proj_obj = sdb.get_project(self.projectname)
             meta_info_dict = proj_obj.get("staged_files", {})

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -2,12 +2,14 @@
     Module for controlling deliveries of samples and projects
 """
 import datetime
+import glob
 import json
 import logging
 import os
 import re
 import signal
 import shutil
+import yaml
 
 from taca.utils.config import CONFIG
 from taca.utils.filesystem import create_folder, chdir
@@ -320,6 +322,39 @@ class Deliverer(object):
                 raise DelivererError(
                     "the path '{}' could not be expanded - reason: {}".format(
                         path, e))
+    
+    def aggregate_meta_info(self):
+        """ A method to collect meta info about delivered files (like size, md5 value)
+            Which files are interested (by default only 'fastq' and 'bam' files) can be
+            controlled by setting 'files_interested' in 'aggregate_meta_info' section.
+            It needs a database credentials file to put the aggregated info.
+        """
+        save_meta_info = getattr(self, 'save_meta_info', False)
+        if not save_meta_info:
+            return False
+        try:
+            with open(os.getenv('STATUS_DB_CONFIG'), 'r') as db_cred_file:
+                db_conf = yaml.load(db_cred_file)['statusdb']
+        except Exception as e:
+            logger.warning("Reading DB config failed due to {}. Meta info will not be saved".format(e))
+            return False
+        # Upload metainfo to couchdb, if fails just move on
+        try:
+            sdb = db.statusdb_session(db_conf, db="projects")
+            proj_obj = sdb.get_project(self.projectname)
+            meta_info_dict = proj_obj.get("staged_files", {})
+            staging_path = self.expand_path(self.stagingpath)
+            hash_files = glob.glob(os.path.join(staging_path, "*.{}".format(self.hash_algorithm)))
+            for hash_file in hash_files:
+                hash_dict = fs.parse_hash_file(hash_file, hash_algorithm=self.hash_algorithm, root_path=staging_path, files_filter=['.fastq', '.bam'])
+                meta_info_dict = fs.merge_dicts(meta_info_dict, hash_dict)
+            proj_obj["staged_files"] = meta_info_dict
+            sdb.save_db_doc(proj_obj)
+            logger.info("Updated metainfo for project {} with id {} in StatusDB".format(self.projectid, proj_obj.get("_id")))
+            return True
+        except Exception as e:
+            logger.warning("Was not able to update metainfo due to error {}".format(e))
+            return False
 
 
 class ProjectDeliverer(Deliverer):
@@ -448,6 +483,8 @@ class ProjectDeliverer(Deliverer):
             if os.path.exists(self.expand_path(self.stagingpath)):
                 # Try to deliver any miscellaneous files for the project (like reports, analysis)
                 ProjectMiscDeliverer(self.projectid).deliver_misc_data()
+                # Try aggregate meta info and update in appropriate DB
+                self.aggregate_meta_info()
             # query the database whether all samples in the project have been sucessfully delivered
             if self.all_samples_delivered():
                 # this is the only delivery status we want to set on the project level, in order to avoid concurrently

--- a/taca_ngi_pipeline/deliver/deliver_grus.py
+++ b/taca_ngi_pipeline/deliver/deliver_grus.py
@@ -23,6 +23,7 @@ from ngi_pipeline.database.classes import CharonSession, CharonError
 from taca.utils.filesystem import do_copy, create_folder
 from taca.utils.config import CONFIG
 
+from ..utils.database import statusdb_session
 from deliver import ProjectDeliverer, SampleDeliverer, DelivererInterruptedError
 
 logger = logging.getLogger(__name__)
@@ -508,13 +509,8 @@ class GrusProjectDeliverer(ProjectDeliverer):
         return matches[0].get("id")
 
     def _get_order_detail(self):
-        url = self.config_statusdb.get('url')
-        username = self.config_statusdb.get('username')
-        password = self.config_statusdb.get('password')
-        port = self.config_statusdb.get('port')
-        status_db_url = 'http://{}:{}@{}:{}'.format(username, password, url, port)
-        status_db = couchdb.Server(status_db_url)
-        projects_db = status_db['projects']
+        status_db = statusdb_session(self.config_statusdb)
+        projects_db = status_db.connection['projects']
         view = projects_db.view('order_portal/ProjectID_to_PortalID')
         rows = view[self.projectid].rows
         if len(rows) < 1:

--- a/taca_ngi_pipeline/utils/database.py
+++ b/taca_ngi_pipeline/utils/database.py
@@ -89,7 +89,7 @@ class statusdb_session(object):
         display_url_string = "http://{}:{}@{}:{}".format(duser, "*********", durl, dport)
         self.connection = couchdb.Server(url=durl_string)
         if not self.connection:
-            raise("Couchdb connection failed for url {}".format(display_url_string))
+            raise Exception("Couchdb connection failed for url {}".format(display_url_string))
         if db:
             self.db_connection = self.connection[db]
     

--- a/taca_ngi_pipeline/utils/database.py
+++ b/taca_ngi_pipeline/utils/database.py
@@ -78,7 +78,7 @@ def update_sample(dbc, projectid, sampleid, **kwargs):
     return _wrap_database_query(dbc.sample_update, projectid, sampleid, **kwargs)
 
 class statusdb_session(object):
-    """Small wrapper class for couchdb utils"""
+    """Small wrapper class for couchdb utils. Made it as class to allow room for expansion"""
     def __init__(self, config, db=None):
         import couchdb #importing here just incase not to break other methods
         duser = config.get("username")
@@ -91,7 +91,7 @@ class statusdb_session(object):
         if not self.connection:
             raise("Couchdb connection failed for url {}".format(display_url_string))
         if db:
-            self._set_db_connection(db)
+            self.db_connection = self.connection[db]
     
     def get_project(self, project):
         try:
@@ -106,7 +106,3 @@ class statusdb_session(object):
             db.save(ddoc)
         except Exception as e:
             raise Exception("Failed saving document due to {}".format(e))
-    
-    def _set_db_connection(self, db):
-        self.db_connection = self.connection[db]
-

--- a/taca_ngi_pipeline/utils/database.py
+++ b/taca_ngi_pipeline/utils/database.py
@@ -76,3 +76,37 @@ def update_sample(dbc, projectid, sampleid, **kwargs):
     :raises DatabaseError: if an error occurred when communicating with the database
     """
     return _wrap_database_query(dbc.sample_update, projectid, sampleid, **kwargs)
+
+class statusdb_session(object):
+    """Small wrapper class for couchdb utils"""
+    def __init__(self, config, db=None):
+        import couchdb #importing here just incase not to break other methods
+        duser = config.get("username")
+        dpwrd = config.get("password")
+        dport = config.get("port")
+        durl = config.get("url")
+        durl_string = "http://{}:{}@{}:{}".format(duser, dpwrd, durl, dport)
+        display_url_string = "http://{}:{}@{}:{}".format(duser, "*********", durl, dport)
+        self.connection = couchdb.Server(url=durl_string)
+        if not self.connection:
+            raise("Couchdb connection failed for url {}".format(display_url_string))
+        if db:
+            self._set_db_connection(db)
+    
+    def get_project(self, project):
+        try:
+            proj_db = self.connection["projects"]
+            return [proj_db.get(k.id) for k in proj_db.view("project/project_name", reduce=False) if k.key == project][0]
+        except Exception as e:
+            raise Exception("Failed getting project due to {}".format(e))
+    
+    def save_db_doc(self, ddoc, db=None):
+        try:
+            db = db or getattr(self, "db_connection")
+            db.save(ddoc)
+        except Exception as e:
+            raise Exception("Failed saving document due to {}".format(e))
+    
+    def _set_db_connection(self, db):
+        self.db_connection = self.connection[db]
+


### PR DESCRIPTION
Having metainfo such as `md5` and `size` of staged samples (which are mostly delivered) is useful for back reference

This is one of the issue I addressed in the big [PR](https://github.com/SciLifeLab/taca-ngi-pipeline/pull/35/files) *(which I closed)* that I made last year. @b97pla had some good comments related to these changes, so I made this PR complementing those suggestions.