### PR TITLE
fix for Charon 'not_under_delivery' status

### DIFF
--- a/taca_ngi_pipeline/deliver/deliver_grus.py
+++ b/taca_ngi_pipeline/deliver/deliver_grus.py
@@ -89,7 +89,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
         """
         dbentry = dbentry or self.db_entry()
         if dbentry.get('delivery_token'):
-            if dbentry.get('delivery_token') != 'NO-TOKEN':
+            if dbentry.get('delivery_token') not in ['NO-TOKEN', 'not_under_delivery'] :
                 return 'IN_PROGRESS' #it means that at least some samples are under delivery
         if  dbentry.get('delivery_status'):
             if dbentry.get('delivery_status') == 'DELIVERED':


### PR DESCRIPTION
Fix for the error 'taca_ngi_pipeline.cli - ERROR - processing Pnnnn failed - reason: Project already under delivery with Mover' when hardstaging projects in IRMA because the project has the delivery-token 'not_under_delivery' in Charon.