### PR TITLE
Adds the delivery project to Project page on statusdb when doing GRUS delivery 

### DIFF
--- a/taca_ngi_pipeline/deliver/deliver_grus.py
+++ b/taca_ngi_pipeline/deliver/deliver_grus.py
@@ -377,7 +377,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
         if not save_meta_info:
             return
         status_db = statusdb_session(self.config_statusdb)
-        project_page=json.loads(json.dumps(status_db.get_project(self.projectid)))
+        project_page=status_db.get_project(self.projectid)
         dprojs=[]
         if 'delivery_projects' in project_page:
             dprojs=project_page['delivery_projects']

--- a/taca_ngi_pipeline/deliver/deliver_grus.py
+++ b/taca_ngi_pipeline/deliver/deliver_grus.py
@@ -313,6 +313,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
             self.save_delivery_token_in_charon(delivery_token)
             #memorise the delivery project so I know each NGi project to how many delivery projects it has been sent
             self.add_supr_name_delivery_in_charon(supr_name_of_delivery)
+            self.add_supr_name_delivery_in_statusdb(supr_name_of_delivery, self.projectid)
             logger.info("Delivery token for project {}, delivery project {} is {}".format(self.projectid,
                                                                                     supr_name_of_delivery,
                                                                                     delivery_token))
@@ -367,6 +368,24 @@ class GrusProjectDeliverer(ProjectDeliverer):
                 logger.warn('Charon delivery_projects for project {} not updated with value {} because the value was already present'.format(self.projectid, supr_name_of_delivery))
         except Exception, e:
             logger.error('Failed to update delivery_projects in charon while delivering {}. Error says: {}'.format(self.projectid, e))
+            logger.exception(e)
+
+    def add_supr_name_delivery_in_statusdb(self, supr_name_of_delivery, projectid):
+        '''Updates delivery_projects in StatusDB at project level
+        '''
+        status_db = statusdb_session(self.config_statusdb)
+        project_page=json.loads(status_db.get_project(projectid))
+        dprojs=[]
+        if 'delivery_projects' in project_page:
+            dprojs=project_page['delivery_projects']
+
+        dprojs.append(supr_name_of_delivery)
+
+        project_page['delivery_projects'] = dprojs
+        try:
+            status_db.connection['projects'].save(project_page)
+        except Exception, e:
+            logger.error('Failed to update delivery_projects in statusdb while delivering {}. Error says: {}'.format(projectid, e))
             logger.exception(e)
 
     def do_delivery(self, supr_name_of_delivery):

--- a/taca_ngi_pipeline/utils/database.py
+++ b/taca_ngi_pipeline/utils/database.py
@@ -92,14 +92,17 @@ class statusdb_session(object):
             raise Exception("Couchdb connection failed for url {}".format(display_url_string))
         if db:
             self.db_connection = self.connection[db]
-    
+
     def get_project(self, project):
+        choose_view = "project/project_name"
+        if "_" not in project:
+            choose_view = "project/project_id"
         try:
             proj_db = self.connection["projects"]
-            return [proj_db.get(k.id) for k in proj_db.view("project/project_name", reduce=False) if k.key == project][0]
+            return [proj_db.get(k.id) for k in proj_db.view(choose_view, reduce=False) if k.key == project][0]
         except Exception as e:
             raise Exception("Failed getting project due to {}".format(e))
-    
+
     def save_db_doc(self, ddoc, db=None):
         try:
             db = db or getattr(self, "db_connection")


### PR DESCRIPTION
The delivery project is written back to the Project page on statusdb during GRUS delivery so it that the field is easier to display in Project list on genomic status.