### PR TITLE
Delivery readme fixes

### DIFF
--- a/delivery_readmes/DELIVERY.README.MethylSeq.txt
+++ b/delivery_readmes/DELIVERY.README.MethylSeq.txt
@@ -46,7 +46,7 @@ The 00-Report folder contains reports with sequencing information about the runs
        ├── ProjectName_project_summary.md
        ├── ProjectName_sample_info.txt
        └── manifestFiles/
-            └── <ProjectID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
+            └── <SampleID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
 
 
 --ProjectName_lanes_info.txt
@@ -67,7 +67,7 @@ The .md file of the project_summary.html file used to generate the report.
 --ProjectName_sample_info.txt
 A file with information about the samples such as names, million reads, and Q30 values.
 
---<ProjectID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
+--<SampleID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
 A file summarizing the run with information about instruments and library.
 
 
@@ -87,7 +87,7 @@ Contains a subfolder for each flowcell, which in turn contains the FastQ files f
 
 ── 02-FASTQ/
    └── <flowcell>/
-       └── <ProjectID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz
+         └── <SampleID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz
 
 ==================================================================
 ProjectID -> results/

--- a/delivery_readmes/DELIVERY.README.MethylSeq.txt
+++ b/delivery_readmes/DELIVERY.README.MethylSeq.txt
@@ -39,14 +39,14 @@ The 00-Report folder contains reports with sequencing information about the runs
 
 ── ProjectID/
    ├── 00-Reports/
-   │   ├── ProjectName_lanes_info.txt
-   │   ├── ProjectName_library_info.txt
-   │   ├── ProjectName_multiqc_report.html
-   │   ├── ProjectName_project_summary.html
-   │   ├── ProjectName_project_summary.md
-   │   └── ProjectName_sample_info.txt
-   └── manifestFiles/
-       └── <NGI_ID>.02-FASTQ.<flowcell>.<NGI_ID>_<flowcell-mode>_<lane-number>_manifest.txt
+       ├── ProjectName_lanes_info.txt
+       ├── ProjectName_library_info.txt
+       ├── ProjectName_multiqc_report.html
+       ├── ProjectName_project_summary.html
+       ├── ProjectName_project_summary.md
+       ├── ProjectName_sample_info.txt
+       └── manifestFiles/
+            └── <ProjectID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
 
 
 --ProjectName_lanes_info.txt
@@ -64,10 +64,10 @@ A report summarising the information about the run, samples, and library.
 --ProjectName_project_summary.md
 The .md file of the project_summary.html file used to generate the report.
 
- --ProjectName_sample_info.txt
+--ProjectName_sample_info.txt
 A file with information about the samples such as names, million reads, and Q30 values.
 
---<NGI-ID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz
+--<ProjectID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
 A file summarizing the run with information about instruments and library.
 
 
@@ -87,7 +87,7 @@ Contains a subfolder for each flowcell, which in turn contains the FastQ files f
 
 ── 02-FASTQ/
    └── <flowcell>/
-       └── <NGI-ID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz
+       └── <ProjectID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz
 
 ==================================================================
 ProjectID -> results/

--- a/delivery_readmes/DELIVERY.README.RAW_DATA.txt
+++ b/delivery_readmes/DELIVERY.README.RAW_DATA.txt
@@ -64,7 +64,7 @@ The 00-Report folder contains reports with sequencing information about the runs
        ├── ProjectName_project_summary.md
        ├── ProjectName_sample_info.txt
        └── manifestFiles/
-            └── <ProjectID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
+            └── <SampleID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
 
 
 --ProjectName_lanes_info.txt
@@ -85,7 +85,7 @@ The .md file of the project_summary.html file used to generate the report.
 --ProjectName_sample_info.txt
 A file with information about the samples such as names, million reads, and Q30 values.
 
---<ProjectID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
+--<SampleID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
 A file summarizing the run with information about instruments and library.
 
 
@@ -105,4 +105,4 @@ Contains a subfolder for each flowcell, which in turn contains the FastQ files f
 
 ── 02-FASTQ/
    └── <flowcell>/
-        └── <ProjectID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz
+         └── <SampleID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz

--- a/delivery_readmes/DELIVERY.README.RAW_DATA.txt
+++ b/delivery_readmes/DELIVERY.README.RAW_DATA.txt
@@ -1,13 +1,34 @@
 README
 =======
 
-Raw data: Delivered files
------------------------------------------------------------------
+Many thanks for sequencing your samples with the SciLifeLab National Genomics Infrastructure!
+This README describes the different files present in your data delivery, including information about verifying file integrity and finding results.
+If you have any questions, please don't hesitate to get in touch: support@ngisweden.se
 
 ==================================================================
 ProjectID
 ==================================================================
-The data delivery comes in a folder named by the NGI project ID. This contains one “00-Reports“ directory, a directory for each sample with its data. The root folder also contains the following files:
+The root folder, which is named by the NGI project ID, contains one report folder and a folder for each sample.
+Each sample folder is accompanied by a .lst-file containing a list of the files in the folder and a .md5-file containing the MD5-checksums of the files in the folder.
+Use the MD5-checksums to verify the integrity of the files after transfer.
+
+├──ProjectID
+   ├── 00-Reports/
+   ├── Sample1/
+   ├── Sample1.lst
+   ├── Sample1.md5
+   ├── Sample2/
+   ├── Sample2.lst
+   ├── Sample2.md5
+   ...
+   ...
+   ├── SampleN/
+   ├── SampleN.lst
+   ├── SampleN.md5
+   ├── ACKNOWLEDGEMENTS.txt
+   ├── DELIVERY.README.RAW_DATA.txt
+   ├── miscellaneous.lst
+   └── miscellaneous.md5
 
 --ACKNOWLEDGEMENTS.txt
 A file describing what to include in any publications using this data.
@@ -18,16 +39,13 @@ A list of the files of the delivery, excluding raw data.
 --miscellaneous.md5
 A file to check the integrity of the miscellaneous.lst file.
 
---SampleN.lst
-A list of the raw data files of SampleN.
-
---SampleN.md5
-A file to check the integrity of the SampleN.lst file.
 
 File integrity checks
 ---------------------
-It is extremely important to check the integrity of the delivered data using the .md5 files. To do this, run the following:
-md5sum -c file_with_checksums.md5
+It is extremely important to check the integrity of the delivered data using the .md5 files. To do this, run the following command in the terminal (replace with the relevant file name):
+
+md5sum -c [checksum_file.md5]
+
 For more information, please see https://ngisweden.scilifelab.se/resources/data-delivery/
 
 
@@ -39,35 +57,35 @@ The 00-Report folder contains reports with sequencing information about the runs
 
 ── ProjectID/
    ├── 00-Reports/
-   │   ├── ProjectName_lanes_info.txt
-   │   ├── ProjectName_library_info.txt
-   │   ├── ProjectName_multiqc_report.html
-   │   ├── ProjectName_project_summary.html
-   │   ├── ProjectName_project_summary.md
-   │   └── ProjectName_sample_info.txt
-   └── manifestFiles/
-       └── <NGI_ID>.02-FASTQ.<flowcell>.<NGI_ID>_<flowcell-mode>_<lane-number>_manifest.txta 
+       ├── ProjectName_lanes_info.txt
+       ├── ProjectName_library_info.txt
+       ├── ProjectName_multiqc_report.html
+       ├── ProjectName_project_summary.html
+       ├── ProjectName_project_summary.md
+       ├── ProjectName_sample_info.txt
+       └── manifestFiles/
+            └── <ProjectID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
 
 
- --ProjectName_lanes_info.txt
-A file with statistics about the run, such as date, FC ID, lane,    million clusters, PhiX error rate, Q30, and method.
+--ProjectName_lanes_info.txt
+A file with statistics about the run, such as date, FC ID, lane, million clusters, PhiX error rate, Q30, and method.
 
 --ProjectName_library_info.txt
 A file with statistics about the library, such as index, library prep, and passing/failing library QC.
 
 --ProjectName_multiqc_report.html
-A HTML report summarising the raw sequencing quality-control results graphically, based on the bioinformatics tools FastQC and FastQ Screen.
+A HTML report summarizing the raw sequencing quality-control results graphically, based on the bioinformatics tools FastQC and FastQ Screen.
 
 --ProjectName_project_summary.html
-A report summarising the information about the run, samples, and library.
+A report summarizing the information about the run, samples, and library.
 
 --ProjectName_project_summary.md
 The .md file of the project_summary.html file used to generate the report.
 
- --ProjectName_sample_info.txt
+--ProjectName_sample_info.txt
 A file with information about the samples such as names, million reads, and Q30 values.
 
---<NGI-ID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz
+--<ProjectID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
 A file summarizing the run with information about instruments and library.
 
 
@@ -78,7 +96,7 @@ Each sample directory will contain the following subfolders:
 
 ── ProjectID/
    └── SampleN/
-       └── 02-FASTQ/
+        └── 02-FASTQ/
 
 ==================================================================
 ProjectID -> SampleN -> 02-FASTQ
@@ -87,4 +105,4 @@ Contains a subfolder for each flowcell, which in turn contains the FastQ files f
 
 ── 02-FASTQ/
    └── <flowcell>/
-       └── <NGI-ID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz
+        └── <ProjectID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz

--- a/delivery_readmes/DELIVERY.README.RNASeq.txt
+++ b/delivery_readmes/DELIVERY.README.RNASeq.txt
@@ -23,7 +23,7 @@ Use the md5 checksums to verify the integrity of the files after transfer.
    ├── Sample2.md5
    ...
    ...
-   │   ├── SampleN/
+   ├── SampleN/
    ├── SampleN.lst
    ├── SampleN.md5
    ├── ACKNOWLEDGEMENTS.txt

--- a/delivery_readmes/DELIVERY.README.RNASeq.txt
+++ b/delivery_readmes/DELIVERY.README.RNASeq.txt
@@ -15,17 +15,17 @@ Use the md5 checksums to verify the integrity of the files after transfer.
 ├──ProjectID
    ├── 00-Reports/
    ├── 01-RNA-Results/
-   │   ├── Sample1/
-   │   ├── Sample1.lst
-   │   ├── Sample1.md5
-   │   ├── Sample2/
-   │   ├── Sample2.lst
-   │   ├── Sample2.md5
+   ├── Sample1/
+   ├── Sample1.lst
+   ├── Sample1.md5
+   ├── Sample2/
+   ├── Sample2.lst
+   ├── Sample2.md5
    ...
    ...
    │   ├── SampleN/
-   │   ├── SampleN.lst
-   │   └── SampleN.md5
+   ├── SampleN.lst
+   ├── SampleN.md5
    ├── ACKNOWLEDGEMENTS.txt
    ├── DELIVERY.README.RNASeq.txt
    ├── miscellaneous.lst

--- a/delivery_readmes/DELIVERY.README.RNASeq.txt
+++ b/delivery_readmes/DELIVERY.README.RNASeq.txt
@@ -62,7 +62,7 @@ ProjectID -> 00-Reports
     ├── ProjectName_library_info.txt
     ├── ProjectName_multiqc_report.html
     └── manifestFiles/
-        └── <ProjectID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
+        └── <SampleID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
 
 --ProjectName_project_summary.html
 A report summarizing information about the project.
@@ -73,7 +73,7 @@ Tab-separated text files for each table found in the report, convenient for load
 --ProjectName_multiqc_report.html
 Report summarizing general quality statistics based on the bioinformatics tools FastQC and FastQ Screen.
 
---<ProjectID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
+--<SampleID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
 A file summarizing the run with information about instruments and library.
 
 
@@ -98,4 +98,4 @@ Contains a subfolder for each flowcell, which in turn contains the FASTQ files.
 
 ├──02-FASTQ/
    └── <Flowcell>/
-       └── <ProjectID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz
+         └── <SampleID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz

--- a/delivery_readmes/DELIVERY.README.Sarek.txt
+++ b/delivery_readmes/DELIVERY.README.Sarek.txt
@@ -55,14 +55,14 @@ ProjectID -> 00-Reports
 00-Reports folder contains the reports with the sample and sequence QC. It also contains a project summary report and MultiQC reports.
 
 ├── 00-Reports/
-    ├── ProjectName_project_summary.html
-    ├── ProjectName_sample_info.txt
-    ├── ProjectName_lane_info.txt
-    ├── ProjectName_library_info.txt
-    ├── ProjectName_multiqc_report.html
-    ├── ProjectName_SarekGermline_multiqc_report.html
-    └── manifestFiles/
-        └── <ProjectID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
+   ├── ProjectName_project_summary.html
+   ├── ProjectName_sample_info.txt
+   ├── ProjectName_lane_info.txt
+   ├── ProjectName_library_info.txt
+   ├── ProjectName_multiqc_report.html
+   ├── ProjectName_SarekGermline_multiqc_report.html
+   └── manifestFiles/
+         └── <ProjectID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
 
 --ProjectName_project_summary.html
 A report summarizing information about the project
@@ -99,4 +99,4 @@ Contains a subfolder for each flowcell, which in turn contains the FASTQ files.
 
 ├──02-FASTQ/
    └── <Flowcell>/
-       └── <ProjectID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz
+         └── <ProjectID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz

--- a/delivery_readmes/DELIVERY.README.Sarek.txt
+++ b/delivery_readmes/DELIVERY.README.Sarek.txt
@@ -62,7 +62,7 @@ ProjectID -> 00-Reports
    ├── ProjectName_multiqc_report.html
    ├── ProjectName_SarekGermline_multiqc_report.html
    └── manifestFiles/
-         └── <ProjectID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
+         └── <SampleID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
 
 --ProjectName_project_summary.html
 A report summarizing information about the project
@@ -76,7 +76,7 @@ Report summarizing general quality statistics based on the bioinformatics tools 
 --ProjectName_SarekGermline_multiqc_report.html
 Report summarizing bioinformatic analysis results for all samples
 
---<ProjectID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
+--<SampleID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
 A file summarizing the run with information about instruments and library.
 
 ====================================================================
@@ -99,4 +99,4 @@ Contains a subfolder for each flowcell, which in turn contains the FASTQ files.
 
 ├──02-FASTQ/
    └── <Flowcell>/
-         └── <ProjectID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz
+         └── <SampleID>_<BCL-conversion-ID>_<lane-number>_<read-number>_<volume>.fastq.gz

--- a/delivery_readmes/DELIVERY.README.Sarek.txt
+++ b/delivery_readmes/DELIVERY.README.Sarek.txt
@@ -71,10 +71,7 @@ A report summarizing information about the project
 Tab-separated text files for each table found in the report, convenient for loading into Excel
 
 --ProjectName_multiqc_report.html
-Report summarizing general quality statistics based on the bioinformatics tools FastQC and FastQ Screen.
-
---ProjectName_SarekGermline_multiqc_report.html
-Report summarizing bioinformatic analysis results for all samples
+Report summarizing general quality statistics and bioinformatic analysis results for all samples.
 
 --<SampleID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
 A file summarizing the run with information about instruments and library.

--- a/delivery_readmes/DELIVERY.README.Sarek.txt
+++ b/delivery_readmes/DELIVERY.README.Sarek.txt
@@ -52,7 +52,7 @@ For more information, please see https://ngisweden.scilifelab.se/resources/data-
 ====================================================================
 ProjectID -> 00-Reports
 ====================================================================
-00-Reports folder contains the reports with the sample and sequence QC. It also contains a project summary report and MultiQC reports.
+00-Reports folder contains the reports with the sample and sequence QC. It also contains a project summary report and a MultiQC report.
 
 ├── 00-Reports/
    ├── ProjectName_project_summary.html
@@ -60,7 +60,6 @@ ProjectID -> 00-Reports
    ├── ProjectName_lane_info.txt
    ├── ProjectName_library_info.txt
    ├── ProjectName_multiqc_report.html
-   ├── ProjectName_SarekGermline_multiqc_report.html
    └── manifestFiles/
          └── <SampleID>.02-FASTQ.<flowcell>.<ProjectID>_<BCL-CONVERSION-ID>_<lane-number>_manifest.txt
 

--- a/delivery_readmes/DELIVERY.README.Sarek.txt
+++ b/delivery_readmes/DELIVERY.README.Sarek.txt
@@ -14,17 +14,17 @@ Use the MD5-checksums to verify the integrity of the files after transfer.
 
 ├──ProjectID
    ├── 00-Reports/
-   │   ├── Sample1/
-   │   ├── Sample1.lst
-   │   ├── Sample1.md5
-   │   ├── Sample2/
-   │   ├── Sample2.lst
-   │   ├── Sample2.md5
+   ├── Sample1/
+   ├── Sample1.lst
+   ├── Sample1.md5
+   ├── Sample2/
+   ├── Sample2.lst
+   ├── Sample2.md5
    ...
    ...
-   │   ├── SampleN/
-   │   ├── SampleN.lst
-   │   └── SampleN.md5
+   ├── SampleN/
+   ├── SampleN.lst
+   ├── SampleN.md5
    ├── ACKNOWLEDGEMENTS.txt
    ├── DELIVERY.README.SAREK.txt
    ├── miscellaneous.lst

--- a/taca_ngi_pipeline/__init__.py
+++ b/taca_ngi_pipeline/__init__.py
@@ -1,4 +1,4 @@
 """ Main taca_ngi_pipeline module
 """
 
-__version__ = '0.8.1'
+__version__ = '0.8.2'

--- a/taca_ngi_pipeline/__init__.py
+++ b/taca_ngi_pipeline/__init__.py
@@ -1,4 +1,4 @@
 """ Main taca_ngi_pipeline module
 """
 
-__version__ = '0.8.2'
+__version__ = '0.8.3'


### PR DESCRIPTION
Updated:
* `DELIVERY.README.MethylSeq.txt`
* `DELIVERY.README.RAW_DATA.txt`
* `DELIVERY.README.RNASeq.txt`
* `DELIVERY.README.Sarek.txt`
  * Moved the samples out of 00-reports to match the PR for the [sarek delivery yaml, bimonthly branch](https://github.com/NationalGenomicsInfrastructure/irma-provision/pull/412)