### PR TITLE
Fix requirements collision

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+decorator<=4.4.2
 click==7.1.2
 traitlets==4.3.3
 bcrypt==3.1.7

--- a/taca_ngi_pipeline/__init__.py
+++ b/taca_ngi_pipeline/__init__.py
@@ -1,4 +1,4 @@
 """ Main taca_ngi_pipeline module
 """
 
-__version__ = '0.8.1'
+__version__ = '0.8.2'


### PR DESCRIPTION
The newest release of the python package [decorator v5](https://pypi.org/project/decorator/#history) requires python>=3.5. The package was downloaded as the latest version by the python package traitlets which can handle any version of decorator. We could therefore limit the decorator version to be below or equal to version 4.4.2.