### PR TITLE
converting path to realpath

### DIFF
--- a/taca_ngi_pipeline/__init__.py
+++ b/taca_ngi_pipeline/__init__.py
@@ -1,4 +1,4 @@
 """ Main taca_ngi_pipeline module
 """
 
-__version__ = '0.8.2'
+__version__ = '0.8.3'

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -199,8 +199,8 @@ class Deliverer(object):
             with open(digestpath, 'w') as dh, open(filelistpath, 'w') as fh:
                 agent = transfer.SymlinkAgent(None, None, relative=True)
                 for src, dst, digest in self.gather_files():
-                    agent.src_path = src
-                    agent.dest_path = dst
+                    agent.src_path = os.path.realpath(src)
+                    agent.dest_path = os.path.realpath(dst)
                     try:
                         agent.transfer()
                     except (transfer.TransferError, transfer.SymlinkError) as e:


### PR DESCRIPTION
A broken symlink is created, using the [transfer function](https://github.com/SciLifeLab/TACA/blob/d21622638a054082375537f319c5f4a928f0a5c6/taca/utils/transfer.py#L308), for the relative path between two paths that both resides within the root directory `/` when the start path is a symlink.

This can be replicated using
`taca -c files_to_deliver.yml deliver --ignore-analysis-status --stage_only project <PROJECTID>`

where the `files_to_deliver.yml` contains:
```
deliver:
    rootpath: "/proj//ngi2016003/nobackup/NGI"
    stagingpath: <ROOTPATH>/DELIVERY/<PROJECTID>
    files_to_deliver:
        -
            - /lupus/ngi/production/latest/resources//TACA/sthlm/DELIVERY.README.SAREK.txt
            - <STAGINGPATH>
            - required: True
```
---

Quick example to check without using taca:
``` python
lup='/lupus/home/peer0069/test.txt'
start='/proj/ngi2016003/nobackup/'

print(os.path.relpath(lup,start))
print(os.path.relpath(os.path.realpath(lup),os.path.realpath(start)))
```
Returns
> '../../../lupus/home/peer0069/test.txt'
  '../../../home/peer0069/test.txt'

Where `/proj` is a link in the root directory, pointing to `/lupus/proj`.

Standing in `/proj/ngi2016003/nobackup/` and accessing the file with `less '../../../lupus/home/peer0069/test.txt'` generates an error that the file doesn't exist, whereas accessing the relative real paths works `less '../../../home/peer0069/test.txt`.
