### PR TITLE
Port to python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
     - "2.7"
+    - "3.8"
 
 before_install:
     - export CHARON_BASE_URL="http://tracking.database.org"

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import glob
 from setuptools import setup, find_packages
 
 from taca_ngi_pipeline import __version__
+from io import open
 
 try:
     with open("requirements.txt", "r") as f:

--- a/taca_ngi_pipeline/__init__.py
+++ b/taca_ngi_pipeline/__init__.py
@@ -1,4 +1,4 @@
 """ Main taca_ngi_pipeline module
 """
 
-__version__ = '0.8.3'
+__version__ = '0.9.0'

--- a/taca_ngi_pipeline/cli.py
+++ b/taca_ngi_pipeline/cli.py
@@ -5,8 +5,8 @@ import logging
 
 from taca.utils.misc import send_mail
 from taca.utils.config import load_yaml_config
-from deliver import deliver as _deliver
-from deliver import deliver_grus as _deliver_grus
+from .deliver import deliver as _deliver
+from .deliver import deliver_grus as _deliver_grus
 
 logger = logging.getLogger(__name__)
 

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -20,6 +20,7 @@ from ..utils import database as db
 from ..utils import filesystem as fs
 from ..utils import nbis_xml_generator as xmlgen
 from io import open
+from six.moves import map
 
 logger = logging.getLogger(__name__)
 
@@ -180,7 +181,7 @@ class Deliverer(object):
                 destination path and the checksum of the source file
                 (or None if source is a folder)
         """
-        return fs.gather_files([map(self.expand_path, file_pattern) for file_pattern in self.files_to_deliver],
+        return fs.gather_files([list(map(self.expand_path, file_pattern)) for file_pattern in self.files_to_deliver],
                                no_checksum=self.no_checksum,
                                hash_algorithm=self.hash_algorithm)
 

--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -19,6 +19,7 @@ from taca.utils import transfer
 from ..utils import database as db
 from ..utils import filesystem as fs
 from ..utils import nbis_xml_generator as xmlgen
+from io import open
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +118,7 @@ class Deliverer(object):
                     self.sampleid or self.projectid)))
             create_folder(os.path.dirname(ackfile))
             with open(ackfile, 'w') as fh:
-                fh.write("{}\n".format(tstamp))
+                fh.write(u"{}\n".format(tstamp))
         except (AttributeError, IOError) as e:
             logger.warning(
                 "could not write delivery acknowledgement, reason: {}".format(
@@ -208,11 +209,11 @@ class Deliverer(object):
                                        "delivering {} - reason: {}".format(src, str(self), e))
 
                     fpath = os.path.relpath(dst, self.expand_path(self.stagingpath))
-                    fh.write("{}\n".format(fpath))
+                    fh.write(u"{}\n".format(fpath))
                     if digest is not None:
-                        dh.write("{}  {}\n".format(digest, fpath))
+                        dh.write(u"{}  {}\n".format(digest, fpath))
                 # finally, include the digestfile in the list of files to deliver
-                fh.write("{}\n".format(os.path.basename(digestpath)))
+                fh.write(u"{}\n".format(os.path.basename(digestpath)))
         except (IOError, fs.FileNotFoundException, fs.PatternNotMatchedException) as e:
             raise DelivererError(
                 "failed to stage delivery - reason: {}".format(e))

--- a/taca_ngi_pipeline/deliver/deliver_grus.py
+++ b/taca_ngi_pipeline/deliver/deliver_grus.py
@@ -21,6 +21,7 @@ from taca.utils.statusdb import StatusdbSession, ProjectSummaryConnection
 
 from .deliver import ProjectDeliverer, SampleDeliverer, DelivererInterruptedError
 from ..utils.database import DatabaseError
+from six.moves import input
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ def proceed_or_not(question):
     no = set(['no', 'n'])
     sys.stdout.write("{}".format(question))
     while True:
-        choice = raw_input().lower()
+        choice = input().lower()
         if choice in yes:
             return True
         elif choice in no:

--- a/taca_ngi_pipeline/deliver/deliver_grus.py
+++ b/taca_ngi_pipeline/deliver/deliver_grus.py
@@ -122,7 +122,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
             try:
                 cmd = ['moverinfo', '-i', delivery_token]
                 output=subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-            except Exception, e:
+            except Exception as e:
                 logger.error('Cannot get the delivery status for project {}'.format(self.projectid))
                 # write Traceback to the log file
                 logger.exception(e)
@@ -172,7 +172,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
                 try:
                     sample_deliverer = GrusSampleDeliverer(self.projectid, sample_id)
                     sample_deliverer.update_delivery_status(status=delivery_status)
-                except Exception, e:
+                except Exception as e:
                     logger.error('Sample {}: Problems in setting sample status on charon. Error: {}'.format(sample_id, e))
                     logger.exception(e)
             #now reset delivery
@@ -186,7 +186,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
                         continue
                     if sample_deliverer.get_delivery_status() != 'DELIVERED':
                         all_samples_delivered = False
-                except Exception, e:
+                except Exception as e:
                     logger.error('Sample {}: Problems in setting sample status on charon. Error: {}'.format(sample_id, e))
                     logger.exception(e)
             if all_samples_delivered:
@@ -240,7 +240,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
         # connect to charon, return list of sample objects that have been staged
         try:
             samples_to_deliver = self.get_samples_from_charon(delivery_status="STAGED")
-        except Exception, e:
+        except Exception as e:
             logger.error("Cannot get samples from Charon. Error says: {}".format(str(e)))
             logger.exception(e)
             raise e
@@ -266,7 +266,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
             try:
                 sample_deliverer = GrusSampleDeliverer(self.projectid, sample_id)
                 sample_deliverer.deliver_sample()
-            except Exception, e:
+            except Exception as e:
                 logger.error('Sample {} has not been hard staged. Error says: {}'.format(sample_id, e))
                 logger.exception(e)
                 raise e
@@ -288,7 +288,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
                 else:
                     shutil.copy(src_misc, dst_misc)
                 hard_staged_misc.append(itm)
-            except Exception, e:
+            except Exception as e:
                 logger.error('Miscellaneous file {} has not been hard staged for project {}. Error says: {}'.format(itm, self.projectid, e))
                 logger.exception(e)
                 raise e
@@ -304,7 +304,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
             delivery_project_info = self._create_delivery_project()
             supr_name_of_delivery = delivery_project_info['name']
             logger.info("Delivery project for project {} has been created. Delivery IDis {}".format(self.projectid, supr_name_of_delivery))
-        except Exception, e:
+        except Exception as e:
             logger.error('Cannot create delivery project. Error says: {}'.format(e))
             logger.exception(e)
         delivery_token = self.do_delivery(supr_name_of_delivery) # instead of to_outbox
@@ -323,7 +323,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
                     sample_deliverer = GrusSampleDeliverer(self.projectid, sample_id)
                     sample_deliverer.save_delivery_token_in_charon(delivery_token)
                     sample_deliverer.add_supr_name_delivery_in_charon(supr_name_of_delivery)
-                except Exception, e:
+                except Exception as e:
                     logger.error('Failed in saving sample infomration for sample {}. Error says: {}'.format(sample_id, e))
                     logger.exception(e)
         else:
@@ -356,7 +356,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
             shutil.copy(runfolder_archive, dst)
             shutil.copy(runfolder_md5file, dst)
             logger.info("Copying files {} and {} to {}".format(runfolder_archive, runfolder_md5file, dst))
-        except IOError, e:
+        except IOError as e:
             logger.error("Unable to copy files to {}. Please check that the files exist and that the filenames match the flowcell ID.".format(dst))
 
         delivery_id = ''
@@ -364,7 +364,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
             delivery_project_info = self._create_delivery_project()
             delivery_id = delivery_project_info['name']
             logger.info("Delivery project for project {} has been created. Delivery IDis {}".format(self.projectid, delivery_id))
-        except Exception, e:
+        except Exception as e:
             logger.error('Cannot create delivery project. Error says: {}'.format(e))
             logger.exception(e)
 
@@ -407,7 +407,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
                 logger.info('Charon delivery_projects for project {} updated with value {}'.format(self.projectid, supr_name_of_delivery))
             else:
                 logger.warn('Charon delivery_projects for project {} not updated with value {} because the value was already present'.format(self.projectid, supr_name_of_delivery))
-        except Exception, e:
+        except Exception as e:
             logger.error('Failed to update delivery_projects in charon while delivering {}. Error says: {}'.format(self.projectid, e))
             logger.exception(e)
 
@@ -429,7 +429,7 @@ class GrusProjectDeliverer(ProjectDeliverer):
         try:
             status_db.save_db_doc(project_page)
             logger.info('Delivery_projects for project {} updated with value {} in statusdb'.format(self.projectid, supr_name_of_delivery))
-        except Exception, e:
+        except Exception as e:
             logger.error('Failed to update delivery_projects in statusdb while delivering {}. Error says: {}'.format(self.projectid, e))
             logger.exception(e)
 
@@ -517,14 +517,14 @@ class GrusProjectDeliverer(ProjectDeliverer):
             try:
                 self.pi_email = self._get_order_detail()['fields']['project_pi_email']
                 logger.info("PI email for project {} found: {}".format(self.projectid, self.pi_email))
-            except Exception, e:
+            except Exception as e:
                 logger.error("Cannot fetch pi_email from StatusDB. Error says: {}".format(str(e)))
                 raise e
         # try getting PI SNIC ID
         try:
             self.pi_snic_id = self._get_user_snic_id(self.pi_email)
             logger.info("SNIC PI-id for delivering of project {} is {}".format(self.projectid, self.pi_snic_id))
-        except Exception, e:
+        except Exception as e:
             logger.error("Cannot fetch PI SNIC id using snic API. Error says: {}".format(str(e)))
             raise e
 
@@ -642,11 +642,11 @@ class GrusSampleDeliverer(SampleDeliverer):
             self.update_delivery_status(status="IN_PROGRESS")
             self.do_delivery()
         #in case of faiulure put again the status to STAGED
-        except DelivererInterruptedError, e:
+        except DelivererInterruptedError as e:
             self.update_delivery_status(status="STAGED")
             logger.exception(e)
             raise(e)
-        except Exception, e:
+        except Exception as e:
             self.update_delivery_status(status="STAGED")
             logger.exception(e)
             raise(e)
@@ -671,7 +671,7 @@ class GrusSampleDeliverer(SampleDeliverer):
                 logger.info('Charon delivery_projects for sample {} updated with value {}'.format(self.sampleid, supr_name_of_delivery))
             else:
                 logger.warn('Charon delivery_projects for sample {} not updated with value {} because the value was already present'.format(self.sampleid, supr_name_of_delivery))
-        except Exception, e:
+        except Exception as e:
             logger.error('Failed to update delivery_projects in charon while delivering {}. Error says: {}'.format(self.sampleid, e))
             logger.exception(e)
 

--- a/taca_ngi_pipeline/utils/database.py
+++ b/taca_ngi_pipeline/utils/database.py
@@ -18,7 +18,7 @@ def _wrap_database_query(query_fn, *query_args, **query_kwargs):
     try:
         return query_fn(*query_args, **query_kwargs)
     except db.CharonError as ce:
-        raise DatabaseError(ce.message)
+        raise DatabaseError(ce)
 
 
 def dbcon():

--- a/taca_ngi_pipeline/utils/filesystem.py
+++ b/taca_ngi_pipeline/utils/filesystem.py
@@ -4,6 +4,7 @@ from glob import iglob
 from logging import getLogger
 from os import path, walk, sep as os_sep
 from taca.utils.misc import hashfile
+from io import open
 
 logger = getLogger(__name__)
 
@@ -44,7 +45,7 @@ def gather_files(patterns, no_checksum=False, hash_algorithm="md5"):
                 if not no_digest_cache:
                     try:
                         with open(checksumpath, 'w') as fh:
-                            fh.write(digest)
+                            fh.write(digest.decode("utf-8"))
                     except IOError as we:
                         logger.warning("could not write checksum {} to file {}: {}".format(digest, checksumpath, we))
         return sourcepath, destpath, digest

--- a/taca_ngi_pipeline/utils/filesystem.py
+++ b/taca_ngi_pipeline/utils/filesystem.py
@@ -9,6 +9,11 @@ import six
 
 logger = getLogger(__name__)
 
+# Handle hashfile output in both python versions
+try:
+    unicode
+except NameError:
+    unicode = str
 
 class FileNotFoundException(Exception):
     pass
@@ -40,13 +45,13 @@ def gather_files(patterns, no_checksum=False, hash_algorithm="md5"):
             checksumpath = "{}.{}".format(sourcepath, hash_algorithm)
             try:
                 with open(checksumpath, 'r') as fh:
-                    digest = next(fh)
+                    digest = unicode(next(fh))
             except IOError:
-                digest = hashfile(sourcepath, hasher=hash_algorithm)
+                digest = unicode(hashfile(sourcepath, hasher=hash_algorithm))
                 if not no_digest_cache:
                     try:
                         with open(checksumpath, 'w') as fh:
-                            fh.write(digest.decode("utf-8"))
+                            fh.write(digest)
                     except IOError as we:
                         logger.warning("could not write checksum {} to file {}: {}".format(digest, checksumpath, we))
         return sourcepath, destpath, digest

--- a/taca_ngi_pipeline/utils/filesystem.py
+++ b/taca_ngi_pipeline/utils/filesystem.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from os import path, walk, sep as os_sep
 from taca.utils.misc import hashfile
 from io import open
+import six
 
 logger = getLogger(__name__)
 
@@ -125,7 +126,7 @@ def merge_dicts(mdict, sdict):
     """Merge the 2 given dictioneries, if a key already exists it is
        replaced/updated with new values depending upon data types
     """
-    for k, v in sdict.iteritems():
+    for k, v in six.iteritems(sdict):
         if isinstance(v, dict) and isinstance(mdict.get(k), dict):
             mdict[k] = merge_dicts(mdict[k], v)
         elif isinstance(v, list) and isinstance(mdict.get(k), list):

--- a/taca_ngi_pipeline/utils/filesystem.py
+++ b/taca_ngi_pipeline/utils/filesystem.py
@@ -40,7 +40,7 @@ def gather_files(patterns, no_checksum=False, hash_algorithm="md5"):
             checksumpath = "{}.{}".format(sourcepath, hash_algorithm)
             try:
                 with open(checksumpath, 'r') as fh:
-                    digest = fh.next()
+                    digest = next(fh)
             except IOError:
                 digest = hashfile(sourcepath, hasher=hash_algorithm)
                 if not no_digest_cache:

--- a/taca_ngi_pipeline/utils/filesystem.py
+++ b/taca_ngi_pipeline/utils/filesystem.py
@@ -130,7 +130,7 @@ def merge_dicts(mdict, sdict):
         if isinstance(v, dict) and isinstance(mdict.get(k), dict):
             mdict[k] = merge_dicts(mdict[k], v)
         elif isinstance(v, list) and isinstance(mdict.get(k), list):
-            mdict[k] = list(set(mdict[k] + v))
+            mdict[k] = sorted(set(mdict[k] + v))
         else:
             mdict[k] = v
     return mdict

--- a/taca_ngi_pipeline/utils/filesystem.py
+++ b/taca_ngi_pipeline/utils/filesystem.py
@@ -111,7 +111,7 @@ def parse_hash_file(hfile, last_modified, hash_algorithm="md5", root_path="", fi
     with open(hfile, 'r') as hfl:
         for hl in hfl:
             hl = hl.strip()
-            if files_filter and not any(map(lambda pat: pat in hl, files_filter)):
+            if files_filter and not any([pat in hl for pat in files_filter]):
                 continue
             hval, fnm = hl.split()
             fkey = fnm.split(os_sep)[0] if os_sep in fnm else path.splitext(fnm)[0]

--- a/taca_ngi_pipeline/utils/nbis_xml_generator.py
+++ b/taca_ngi_pipeline/utils/nbis_xml_generator.py
@@ -5,9 +5,9 @@ import couchdb
 import os
 import re
 import logging
+import six
 
 from collections import defaultdict
-from past.builtins import basestring
 
 
 class xml_generator(object):
@@ -278,7 +278,7 @@ class xml_generator(object):
 
     def _check_and_load_project(self, project):
         """ Get the project document from couchDB if it is not """
-        if isinstance(project, basestring):
+        if isinstance(project, six.string_types):
             self.LOG.info("Fetching project '{}' from statusDB".format(project))
             project = self.pcon.get_entry(project, use_id_view=True)
         self.project = project

--- a/taca_ngi_pipeline/utils/nbis_xml_generator.py
+++ b/taca_ngi_pipeline/utils/nbis_xml_generator.py
@@ -8,6 +8,7 @@ import logging
 import six
 
 from collections import defaultdict
+from io import open
 
 
 class xml_generator(object):
@@ -79,10 +80,10 @@ class xml_generator(object):
             #create manifest files for sample_entry
             self._generate_manifest_file(sample_stat['experiment'], sample_stat['run'])
         # wrap in final xml string tags
-        experiment_set = ('<EXPERIMENT_SET xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+        experiment_set = (u'<EXPERIMENT_SET xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
                           'xsi:noNamespaceSchemaLocation="ftp://ftp.sra.ebi.ac.uk/meta/xsd/sra_1_5/SRA.experiment.xsd">'
                           '\n{}\n</EXPERIMENT_SET>\n').format(experiment_xml_string)
-        run_set = ('<RUN_SET  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+        run_set = (u'<RUN_SET  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
                    'xsi:noNamespaceSchemaLocation="ftp://ftp.sra.ebi.ac.uk/meta/xsd/sra_1_5/SRA.run.xsd">'
                    '\n{}\n</RUN_SET>\n').format(run_xml_string)
         # dont save in file if asked to return as string
@@ -95,7 +96,7 @@ class xml_generator(object):
             rxml.write(run_set)
 
     def _generate_manifest_file(self, exp_details, run_details):
-        fcontents =  ('STUDY\t{}\n').format(exp_details['study'])
+        fcontents =  (u'STUDY\t{}\n').format(exp_details['study'])
         fcontents += ('SAMPLE\t{}\n').format(exp_details['discriptor'])
         fcontents += ('NAME\t{}\n').format(exp_details['alias'])
         fcontents += ('INSTRUMENT\t{}\n').format(exp_details['instrument'])

--- a/taca_ngi_pipeline/utils/nbis_xml_generator.py
+++ b/taca_ngi_pipeline/utils/nbis_xml_generator.py
@@ -147,7 +147,7 @@ class xml_generator(object):
         """ Go through the flowcells and collect needed informations """
         self.sample_aggregated_stat = defaultdict(dict)
         # try to get instrument type and samples sequenced
-        for fc, fc_info in self.flowcells.iteritems():
+        for fc, fc_info in six.iteritems(self.flowcells):
             fc_obj = self.xcon.get_entry(fc_info['run_name']) if fc_info['db'] == 'x_flowcells' else self.fcon.get_entry(fc_info['run_name'])
             if not fc_obj:
                 self.LOG.warn("Could not fetch flowcell {} from {} db, will remove it from list".format(fc_info['run_name'], fc_info['db']))
@@ -175,7 +175,7 @@ class xml_generator(object):
                     if not self.ignore_lib_prep:
                         try:
                             sample_preps_fcs = self.sample_prep_fc_map.get(lane_sample)
-                            prep_id_list = [pid for pid, seqruns in sample_preps_fcs.iteritems() if full_run_id in seqruns]
+                            prep_id_list = [pid for pid, seqruns in six.iteritems(sample_preps_fcs) if full_run_id in seqruns]
                             assert len(prep_id_list) == 1
                             prep_id = prep_id_list[0]
                         except AssertionError:
@@ -266,7 +266,7 @@ class xml_generator(object):
     def _generate_files_block(self, files, flowcells=None):
         """ Take a 'files' dict and give xml block string to include in final xml """
         file_block = ""
-        for fl, fl_stat in files.iteritems():
+        for fl, fl_stat in six.iteritems(files):
             # collect only fastq files
             if not fl.endswith('fastq.gz'):
                 continue
@@ -302,7 +302,7 @@ class xml_generator(object):
         if not self.ignore_lib_prep:
             for sample in self.samples_delivered.keys():
                 sample_preps = self.project.get("samples", {}).get(sample, {}).get("library_prep", {})
-                for prep, prep_info in sample_preps.iteritems():
+                for prep, prep_info in six.iteritems(sample_preps):
                     self.sample_prep_fc_map[sample][prep] = prep_info.get("sequenced_fc", [])
 
 

--- a/tests/deliver/test_deliver.py
+++ b/tests/deliver/test_deliver.py
@@ -17,6 +17,7 @@ from taca.utils.filesystem import create_folder
 from taca.utils.misc import hashfile
 from taca.utils.transfer import SymlinkError, SymlinkAgent
 from io import open
+from six.moves import range
 
 SAMPLECFG = {
     'deliver': {
@@ -102,7 +103,7 @@ class TestDeliverer(unittest.TestCase):
     def create_content(self, parentdir, level=0, folder=0):
         if not os.path.exists(parentdir):
             os.mkdir(parentdir)
-        for nf in xrange(self.nfiles):
+        for nf in range(self.nfiles):
             open(
                 os.path.join(
                     parentdir,
@@ -111,7 +112,7 @@ class TestDeliverer(unittest.TestCase):
         if level == self.nlevels:
             return
         level += 1
-        for nd in xrange(self.nfolders):
+        for nd in range(self.nfolders):
             self.create_content(
                 os.path.join(
                     parentdir,
@@ -157,7 +158,7 @@ class TestDeliverer(unittest.TestCase):
             os.path.join(
                 self.deliverer.expand_path(self.deliverer.analysispath),
                 "level0_folder0_file{}".format(n))
-            for n in xrange(self.nfiles)]
+            for n in range(self.nfiles)]
         pattern = SAMPLECFG['deliver']['files_to_deliver'][0]
         self.deliverer.files_to_deliver = [pattern]
         self.assertItemsEqual(
@@ -179,8 +180,8 @@ class TestDeliverer(unittest.TestCase):
     def test_gather_files3(self):
         """ Gather the files two levels down """
         expected = ["level2_folder{}_file{}".format(m, n)
-                    for m in xrange(self.nfolders)
-                    for n in xrange(self.nfiles)]
+                    for m in range(self.nfolders)
+                    for n in range(self.nfiles)]
         pattern = SAMPLECFG['deliver']['files_to_deliver'][2]
         self.deliverer.files_to_deliver = [pattern]
         self.assertItemsEqual(
@@ -190,7 +191,7 @@ class TestDeliverer(unittest.TestCase):
     def test_gather_files4(self):
         """ Replace the SAMPLE keyword in pattern """
         expected = ["level1_folder{}_file0".format(n)
-                    for n in xrange(self.nfolders)]
+                    for n in range(self.nfolders)]
         pattern = SAMPLECFG['deliver']['files_to_deliver'][3]
         self.deliverer.files_to_deliver = [pattern]
         self.deliverer.sampleid = "level1"
@@ -288,9 +289,9 @@ class TestDeliverer(unittest.TestCase):
             "failed when setting up test")
 
         expected = [os.path.join(dest_path, "level3_folder1_file{}".format(n))
-                    for n in xrange(self.nfiles)]
+                    for n in range(self.nfiles)]
         expected.extend([os.path.join(dest_path, "level3_folder0", "level3_folder0_file{}".format(n))
-                         for n in xrange(self.nfiles)])
+                         for n in range(self.nfiles)])
         pattern = SAMPLECFG['deliver']['files_to_deliver'][6]
         self.deliverer.files_to_deliver = [pattern]
         self.assertItemsEqual(
@@ -415,7 +416,7 @@ class TestDeliverer(unittest.TestCase):
         self.deliverer.stage_delivery()
         self.assertItemsEqual(
             [os.path.exists(e) for e in expected],
-            [True for _ in xrange(len(expected))])
+            [True for _ in range(len(expected))])
 
     def test_expand_path(self):
         """ Paths should expand correctly """
@@ -680,11 +681,11 @@ class TestSampleDeliverer(unittest.TestCase):
         expected = []
         with open(digestfile, 'w') as dh, open(filelist, 'w') as fh:
             curdir = basedir
-            for d in xrange(4):
+            for d in range(4):
                 if d > 0:
                     curdir = os.path.join(curdir, "folder{}".format(d))
                     create_folder(curdir)
-                for n in xrange(5):
+                for n in range(5):
                     fpath = os.path.join(curdir, "file{}".format(n))
                     open(fpath, 'w').close()
                     rpath = os.path.relpath(fpath, basedir)

--- a/tests/deliver/test_deliver.py
+++ b/tests/deliver/test_deliver.py
@@ -263,7 +263,7 @@ class TestDeliverer(unittest.TestCase):
             tpat = list(pattern)
             tpat.append({'no_digest': True})
             self.deliverer.files_to_deliver = [tpat]
-            self.assertTrue(all(map(lambda d: d[2] is None, self.deliverer.gather_files())),
+            self.assertTrue(all([d[2] is None for d in self.deliverer.gather_files()]),
                             "the digest for files with no_digest=True was computed")
 
     def test_gather_files7(self):

--- a/tests/deliver/test_deliver.py
+++ b/tests/deliver/test_deliver.py
@@ -1,6 +1,6 @@
 """ Unit tests for the deliver commands """
 
-import __builtin__
+import six.moves.builtins
 import json
 # noinspection PyPackageRequirements
 import mock
@@ -239,7 +239,7 @@ class TestDeliverer(unittest.TestCase):
                 taca_ngi_pipeline.utils.filesystem, 'hashfile', return_value=exp_checksum):
             # ensure that a thrown IOError when writing checksum cache file is handled gracefully
             # mock hashfile's call to open builtin
-            with mock.patch.object(__builtin__, 'open', side_effect=IOError("mocked IOError")) as iomock:
+            with mock.patch.object(six.moves.builtins, 'open', side_effect=IOError("mocked IOError")) as iomock:
                 for spath, _, obs_checksum in self.deliverer.gather_files():
                     checksumfile = "{}.{}".format(
                         spath, self.deliverer.hash_algorithm)

--- a/tests/deliver/test_deliver.py
+++ b/tests/deliver/test_deliver.py
@@ -232,7 +232,7 @@ class TestDeliverer(unittest.TestCase):
             self.assertTrue(os.path.exists(checksumfile),
                             "checksum cache file was not created")
             with open(checksumfile, 'r') as fh:
-                obs_checksum = fh.next()
+                obs_checksum = next(fh)
             self.assertEqual(obs_checksum, exp_checksum,
                              "cached and returned checksums did not match")
             os.unlink(checksumfile)

--- a/tests/deliver/test_deliver.py
+++ b/tests/deliver/test_deliver.py
@@ -161,7 +161,7 @@ class TestDeliverer(unittest.TestCase):
             for n in range(self.nfiles)]
         pattern = SAMPLECFG['deliver']['files_to_deliver'][0]
         self.deliverer.files_to_deliver = [pattern]
-        self.assertItemsEqual(
+        self.assertEqual(
             [p for p, _, _ in self.deliverer.gather_files()],
             expected)
 
@@ -173,7 +173,7 @@ class TestDeliverer(unittest.TestCase):
                 "level1_folder2")) for f in files]
         pattern = SAMPLECFG['deliver']['files_to_deliver'][1]
         self.deliverer.files_to_deliver = [pattern]
-        self.assertItemsEqual(
+        self.assertEqual(
             [p for p, _, _ in self.deliverer.gather_files()],
             expected)
 
@@ -184,9 +184,9 @@ class TestDeliverer(unittest.TestCase):
                     for n in range(self.nfiles)]
         pattern = SAMPLECFG['deliver']['files_to_deliver'][2]
         self.deliverer.files_to_deliver = [pattern]
-        self.assertItemsEqual(
-            [os.path.basename(p) for p, _, _ in self.deliverer.gather_files()],
-            expected)
+        self.assertEqual(
+            sorted([os.path.basename(p) for p, _, _ in self.deliverer.gather_files()]),
+            sorted(expected))
 
     def test_gather_files4(self):
         """ Replace the SAMPLE keyword in pattern """
@@ -195,16 +195,16 @@ class TestDeliverer(unittest.TestCase):
         pattern = SAMPLECFG['deliver']['files_to_deliver'][3]
         self.deliverer.files_to_deliver = [pattern]
         self.deliverer.sampleid = "level1"
-        self.assertItemsEqual(
-            [os.path.basename(p) for p, _, _ in self.deliverer.gather_files()],
-            expected)
+        self.assertEqual(
+            sorted([os.path.basename(p) for p, _, _ in self.deliverer.gather_files()]),
+            sorted(expected))
 
     def test_gather_files5(self):
         """ Do not pick up non-existing file """
         expected = []
         pattern = SAMPLECFG['deliver']['files_to_deliver'][4]
         self.deliverer.files_to_deliver = [pattern]
-        self.assertItemsEqual(
+        self.assertEqual(
             [os.path.basename(p) for p, _, _ in self.deliverer.gather_files()],
             expected)
 
@@ -294,9 +294,9 @@ class TestDeliverer(unittest.TestCase):
                          for n in range(self.nfiles)])
         pattern = SAMPLECFG['deliver']['files_to_deliver'][6]
         self.deliverer.files_to_deliver = [pattern]
-        self.assertItemsEqual(
-            [p for p, _, _ in self.deliverer.gather_files()],
-            expected)
+        self.assertEqual(
+            sorted([p for p, _, _ in self.deliverer.gather_files()]),
+            sorted(expected))
 
     def test_gather_files8(self):
         """ Skip checksum files """
@@ -304,7 +304,7 @@ class TestDeliverer(unittest.TestCase):
         pattern = SAMPLECFG['deliver']['files_to_deliver'][7]
         self.deliverer.files_to_deliver = [pattern]
         open(self.deliverer.expand_path(pattern[0]), 'w').close()
-        self.assertItemsEqual(
+        self.assertEqual(
             [obs for obs in self.deliverer.gather_files()],
             expected)
 
@@ -321,7 +321,7 @@ class TestDeliverer(unittest.TestCase):
             spath)
         self.deliverer.files_to_deliver = [pattern]
         observed = [p for p, _, _ in self.deliverer.gather_files()]
-        self.assertItemsEqual(observed, expected)
+        self.assertEqual(observed, expected)
 
     def test_gather_files10(self):
         """ A missing required file should throw an error """
@@ -414,7 +414,7 @@ class TestDeliverer(unittest.TestCase):
         pattern = SAMPLECFG['deliver']['files_to_deliver'][1]
         self.deliverer.files_to_deliver = [pattern]
         self.deliverer.stage_delivery()
-        self.assertItemsEqual(
+        self.assertEqual(
             [os.path.exists(e) for e in expected],
             [True for _ in range(len(expected))])
 
@@ -704,7 +704,7 @@ class TestSampleDeliverer(unittest.TestCase):
         # list the trasferred files relative to the destination
         observed = [os.path.relpath(os.path.join(d, f), destination)
                     for d, _, files in os.walk(destination) for f in files]
-        self.assertItemsEqual(observed, expected)
+        self.assertEqual(sorted(observed), sorted(expected))
 
     def test_acknowledge_sample_delivery(self):
         """ A sample delivery acknowledgement should be written to disk """

--- a/tests/deliver/test_deliver.py
+++ b/tests/deliver/test_deliver.py
@@ -1,6 +1,5 @@
 """ Unit tests for the deliver commands """
 
-import six.moves.builtins
 import json
 # noinspection PyPackageRequirements
 import mock
@@ -13,9 +12,11 @@ import unittest
 
 from ngi_pipeline.database import classes as db
 from taca_ngi_pipeline.deliver import deliver
+from taca_ngi_pipeline.utils import filesystem as fs
 from taca.utils.filesystem import create_folder
 from taca.utils.misc import hashfile
 from taca.utils.transfer import SymlinkError, SymlinkAgent
+from io import open
 
 SAMPLECFG = {
     'deliver': {
@@ -214,7 +215,7 @@ class TestDeliverer(unittest.TestCase):
         checksumfile = "{}.{}".format(
             self.deliverer.expand_path(pattern[0]),
             self.deliverer.hash_algorithm)
-        exp_checksum = "this checksum should be cached"
+        exp_checksum = u"this checksum should be cached"
         with open(checksumfile, 'w') as fh:
             fh.write(exp_checksum)
         for _, _, obs_checksum in self.deliverer.gather_files():
@@ -239,7 +240,7 @@ class TestDeliverer(unittest.TestCase):
                 taca_ngi_pipeline.utils.filesystem, 'hashfile', return_value=exp_checksum):
             # ensure that a thrown IOError when writing checksum cache file is handled gracefully
             # mock hashfile's call to open builtin
-            with mock.patch.object(six.moves.builtins, 'open', side_effect=IOError("mocked IOError")) as iomock:
+            with mock.patch.object(fs, 'open', side_effect=IOError("mocked IOError")) as iomock:
                 for spath, _, obs_checksum in self.deliverer.gather_files():
                     checksumfile = "{}.{}".format(
                         spath, self.deliverer.hash_algorithm)
@@ -690,11 +691,11 @@ class TestSampleDeliverer(unittest.TestCase):
                     digest = hashfile(fpath, hasher=self.deliverer.hash_algorithm)
                     if n < 3:
                         expected.append(rpath)
-                        fh.write("{}\n".format(rpath))
-                        dh.write("{}  {}\n".format(digest, rpath))
+                        fh.write(u"{}\n".format(rpath))
+                        dh.write(u"{}  {}\n".format(digest, rpath))
             rpath = os.path.basename(digestfile)
             expected.append(rpath)
-            fh.write("{}\n".format(rpath))
+            fh.write(u"{}\n".format(rpath))
         # transfer the listed content
         destination = self.deliverer.expand_path(self.deliverer.deliverypath)
         create_folder(os.path.dirname(destination))

--- a/tests/deliver/test_deliver_grus.py
+++ b/tests/deliver/test_deliver_grus.py
@@ -45,7 +45,7 @@ SAMPLECFG = {
 
 class TestMisc(unittest.TestCase):
     
-    @patch('taca_ngi_pipeline.deliver.deliver_grus.raw_input')
+    @patch('taca_ngi_pipeline.deliver.deliver_grus.input')
     def test_proceed_or_not(self, mock_input):
         mock_input.return_value = 'y'
         self.assertTrue(proceed_or_not('Q'))

--- a/tests/utils/test_filesystem.py
+++ b/tests/utils/test_filesystem.py
@@ -40,4 +40,4 @@ class TestFilesystem(unittest.TestCase):
                                'a2': ['c', 'd']}, 
                          'B': 'b1',
                          'C': 'c1'}
-        self.assertEqual(merged_dict, expected_dict)
+        self.assertDictEqual(merged_dict, expected_dict)


### PR DESCRIPTION
Should now be compatible with both python 2.7 and 3 🎉 

I'm pretty sure the order in the list returned by the [merge_dicts](https://github.com/ssjunnebo/taca-ngi-pipeline/blob/5ff8a884961555deaee314f915be9092c041bd4c/taca_ngi_pipeline/utils/filesystem.py#L138) function does not matter. It differed between the python versions so I decided to sort it. Please correct me if I'm wrong or you think of a better way to fix this! 🙂 