### PR TITLE
Replace project description to project name plus date

### DIFF
--- a/taca_ngi_pipeline/deliver/deliver_dds.py
+++ b/taca_ngi_pipeline/deliver/deliver_dds.py
@@ -8,6 +8,7 @@ import json
 import subprocess
 import sys
 import re
+import datetime
 
 from ngi_pipeline.database.classes import CharonSession
 from taca.utils.filesystem import create_folder
@@ -478,12 +479,8 @@ class DDSProjectDeliverer(ProjectDeliverer):
         if not self.project_desc:
             try:
                 prj_order = self._get_order_detail()
-                self.project_desc = prj_order['fields']['project_desc'].replace('\n', ' ')
-                if len(self.project_desc) > 24:
-                    short_desc = self.project_desc[:25] + '...'
-                else:
-                    short_desc = self.project_desc
-                logger.info("Project description for project {} found: {}".format(self.projectid, short_desc))
+                self.project_desc = prj_order['project_name'] + ' (' + datetime.datetime.now().strftime("%Y-%m-%d") + ')'
+                logger.info("Project description for project {} found: {}".format(self.projectid, self.project_desc))
             except Exception as e:
                     logger.exception("Cannot fetch project description from StatusDB.")
                     raise e

--- a/taca_ngi_pipeline/deliver/deliver_dds.py
+++ b/taca_ngi_pipeline/deliver/deliver_dds.py
@@ -477,12 +477,8 @@ class DDSProjectDeliverer(ProjectDeliverer):
             logger.warning("Project description for project {} specified by user: {}".format(self.projectid, given_desc))
             self.project_desc = given_desc
         if not self.project_desc:
-            try:
-                self.project_desc = self.projectname + ' (' + datetime.datetime.now().strftime("%Y-%m-%d") + ')'
-                logger.info("Project description for project {}: {}".format(self.projectid, self.project_desc))
-            except Exception as e:
-                    logger.exception("Cannot set project description from StatusDB.")
-                    raise e
+            self.project_desc = self.projectname + ' (' + datetime.datetime.now().strftime("%Y-%m-%d") + ')'
+            logger.info("Project description for project {}: {}".format(self.projectid, self.project_desc))
 
     def _get_order_detail(self):
         """Fetch order details from order portal"""

--- a/taca_ngi_pipeline/deliver/deliver_dds.py
+++ b/taca_ngi_pipeline/deliver/deliver_dds.py
@@ -478,11 +478,10 @@ class DDSProjectDeliverer(ProjectDeliverer):
             self.project_desc = given_desc
         if not self.project_desc:
             try:
-                prj_order = self._get_order_detail()
-                self.project_desc = prj_order['project_name'] + ' (' + datetime.datetime.now().strftime("%Y-%m-%d") + ')'
-                logger.info("Project description for project {} found: {}".format(self.projectid, self.project_desc))
+                self.project_desc = self.projectname + ' (' + datetime.datetime.now().strftime("%Y-%m-%d") + ')'
+                logger.info("Project description for project {}: {}".format(self.projectid, self.project_desc))
             except Exception as e:
-                    logger.exception("Cannot fetch project description from StatusDB.")
+                    logger.exception("Cannot set project description from StatusDB.")
                     raise e
 
     def _get_order_detail(self):


### PR DESCRIPTION
Hi, Jun and I discussed the current DDS setup, and agreed that at present the field `description` is too long to be informative. It should have been a description for the DDS delivery project rather than the long description information of that original user project.

My suggestion is to change it into `[project_name] (date)`, e.g., `C.Wang_22_01 (2022-08-23)`.

Please let me know if you have any better suggestion! Thanks!