### PR TITLE
Always include requester in DDS delivery

### DIFF
--- a/taca_ngi_pipeline/deliver/deliver_dds.py
+++ b/taca_ngi_pipeline/deliver/deliver_dds.py
@@ -55,7 +55,7 @@ class DDSProjectDeliverer(ProjectDeliverer):
             raise AttributeError("Order portal configuration is needed when delivering to DDS")
         if self.orderportal:
             self._set_pi_email(pi_email)
-            self._set_other_member_details(add_user, CONFIG.get('add_project_owner', False), ignore_orderportal_members)
+            self._set_other_member_details(add_user, ignore_orderportal_members)
             self._set_project_details(projectid, project_description)
         self.sensitive = sensitive
         self.fcid = fcid
@@ -446,7 +446,7 @@ class DDSProjectDeliverer(ProjectDeliverer):
                 logger.exception("Cannot fetch pi_email from StatusDB.")
                 raise e
 
-    def _set_other_member_details(self, other_member_emails=[], include_owner=False, ignore_orderportal_members=False):
+    def _set_other_member_details(self, other_member_emails=[], ignore_orderportal_members=False):
         """Set other contact details if available, this is not mandatory so
         the method will not raise error if it could not find any contact
         """
@@ -456,10 +456,9 @@ class DDSProjectDeliverer(ProjectDeliverer):
             logger.info("Fetching additional members from order portal.")
             try:
                 prj_order = self._get_order_detail()
-                if include_owner:
-                    owner_email = prj_order.get('owner', {}).get('email')
-                    if owner_email and owner_email != self.pi_email and owner_email not in other_member_emails:
-                        other_member_emails.append(owner_email)
+                owner_email = prj_order.get('owner', {}).get('email')
+                if owner_email and owner_email != self.pi_email and owner_email not in other_member_emails:
+                    other_member_emails.append(owner_email)
                 binfo_email = prj_order.get('fields', {}).get('project_bx_email')
                 if binfo_email and binfo_email != self.pi_email and binfo_email not in other_member_emails:
                     other_member_emails.append(binfo_email)


### PR DESCRIPTION
Previously only the PI and bioinformatician were added to dds projects unless otherwise specified in the taca config. Instead, always include the project owner/requester.