### PR TITLE
Catch exception and fix filepath

### DIFF
--- a/taca_ngi_pipeline/deliver/deliver.py
+++ b/taca_ngi_pipeline/deliver/deliver.py
@@ -680,7 +680,7 @@ class SampleDeliverer(Deliverer):
                     return True
                 if self.get_sample_status(sampleentry) == 'FRESH' \
                         and not self.force:
-                    logger.info("{} is marked as FRESH (new unporcessed data is available)and will not be delivered".format(str(self)))
+                    logger.info("{} is marked as FRESH (new unprocessed data is available) and will not be delivered".format(str(self)))
                     return False
                 if self.get_delivery_status(sampleentry) == 'FAILED':
                     logger.info("retrying delivery of previously failed sample {}".format(str(self)))

--- a/taca_ngi_pipeline/utils/filesystem.py
+++ b/taca_ngi_pipeline/utils/filesystem.py
@@ -47,12 +47,12 @@ def gather_files(patterns, no_checksum=False, hash_algorithm="md5"):
                 with open(checksumpath, 'r') as fh:
                     contents = unicode(next(fh))
                     digest = contents.split()[0]
-            except IOError:
+            except (IOError, StopIteration):
                 digest = unicode(hashfile(sourcepath, hasher=hash_algorithm))
                 if not no_digest_cache:
                     try:
                         with open(checksumpath, 'w') as fh:
-                            fh.write(f'{digest}  {path.basename(checksumpath)}')
+                            fh.write(f'{digest}  {path.basename(sourcepath)}')
                     except IOError as we:
                         logger.warning("could not write checksum {} to file {}: {}".format(digest, checksumpath, we))
         return sourcepath, destpath, digest


### PR DESCRIPTION
* StopIteration is triggered when the md5 checksum file is empty.